### PR TITLE
feat: add IL-1RA to laboratory_test enum in molecular_test

### DIFF
--- a/gdcdictionary/schemas/molecular_test.yaml
+++ b/gdcdictionary/schemas/molecular_test.yaml
@@ -945,6 +945,7 @@ properties:
     - Urine NGAL
     - ORM1
     - AhR Activity
+    - IL-1RA
   test_value:
     description: The text term or numeric value used to describe a sepcific result
       of a molecular test.

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "049916568851042f8e86ed536435b50741085573",
-        "_dict_version": "2.2.2"
+        "_dict_commit": "619d611f808c16040c24c82bad5a8bc3cbce1c9b",
+        "_dict_version": "2.2.3-molecular-test-il1ra"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -11195,7 +11195,8 @@
                     "Urine L-FABP",
                     "Urine NGAL",
                     "ORM1",
-                    "AhR Activity"
+                    "AhR Activity",
+                    "IL-1RA"
                 ]
             },
             "test_value": {


### PR DESCRIPTION
## Summary

Adds IL-1RA to the laboratory_test enum in the molecular_test schema node.

## Changes
- gdcdictionary/schemas/molecular_test.yaml: Added IL-1RA to the laboratory_test enum
- schema.json: Regenerated after validation

## Validation
All 20 dictutils tests pass.