### PR TITLE
feat: add GitHub Actions deployment workflow

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -3,10 +3,9 @@ name: Deploy Release to S3
 on:
   push:
     tags:
-      - '*.*.*'   # Semantic version tags (e.g., v1.2.3)
+      - 'v[0-9]+.[0-9]+.[0-9]+'   # Release tags only (e.g., v1.2.3) — excludes dev/pre-release tags
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 
 jobs:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,32 @@
+name: Deploy Release to S3
+
+on:
+  push:
+    tags:
+      - '*.*.*'   # Semantic version tags (e.g., v1.2.3)
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get tag name
+        id: get_tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Upload schema.json to S3
+        run: |
+          aws s3 cp schema.json s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.TAG_NAME }}/schema.json

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -3,7 +3,7 @@ name: Deploy Release to S3
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'   # Release tags only (e.g., v1.2.3) — excludes dev/pre-release tags
+      - '[0-9]+.[0-9]+.[0-9]+'   # Release tags only (e.g., v1.2.3) — excludes dev/pre-release tags
 
 permissions:
   contents: read    # This is required for actions/checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Instructions for ARDaC Data Dictionary
+
+## Build, Test, and Lint Commands
+
+- **Validate Dictionary:** Run validation using the provided Docker image. This checks the schemas and generates a `schema.json` file.
+  ```bash
+  docker run --rm -v $(pwd):/mnt/host quay.io/rds/dictutils
+  ```
+  Note: On Windows PowerShell, use `${PWD}` instead of `$(pwd)`.
+
+- **Versioning for Validation:** To ensure the generated `schema.json` has the correct version, create a git tag before running validation:
+  ```bash
+  git tag <version-tag>
+  # Then run validation
+  ```
+
+- **CI/CD:** Validation is automated in GitHub Actions via `.github/workflows/pr-validation.yml` using the same Docker command.
+
+## High-level Architecture
+
+- **Format:** This repository defines a data dictionary for the Gen3 data commons platform using the [dictionaryutils](https://github.com/uc-cdis/dictionaryutils) library.
+- **Schemas:** Data nodes are defined in YAML files located in `gdcdictionary/schemas/`.
+- **Package:** The `gdcdictionary` Python package (defined in `setup.py`) exposes a `DataDictionary` instance initialized with these schemas.
+- **Output:** The primary build artifact is `schema.json`, which is deployed to the Gen3 environment.
+
+## Key Conventions
+
+- **Workflow:** This project follows Gitflow:
+  - Feature branches (`feat/*`) are created from and merged back into `develop`.
+  - Release branches (`release/*`) are used to prepare releases from `develop` to `main`.
+  - Hotfixes (`hotfix/*`) are for critical fixes on `main`.
+- **Root Execution:** Always run the validation command from the repository root to ensure all schema files are found correctly.
+- **Custom Keywords:** The schemas use custom keywords like `systemAlias` (database storage name), `systemProperties` (immutable by submitter), and `parentType` (relationship target).
+- **Branch Naming:** Use descriptive branch names like `feat/new-file-type`.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Deployable versions of the ARDaC data dictionary are available at https://dictio
 To recreate a version of the dictionary, check out the appropriate tag and use the Gen3 [dictionaryutils](https://github.com/uc-cdis/dictionaryutils) to create a JSON file that can be deployed in Gen3.
 
 For step-by-step instructions on how to make changes to the dictionary, please see the `development` guide in the `DOCS` folder.
+
+For instructions on setting up automated deployments to S3, please see the [deployment guide](docs/deployment.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,10 +4,10 @@ This document explains how to set up the automated deployment pipeline for ARDaC
 
 ## Deployment Overview
 
-The deployment workflow is triggered automatically when a new semantic version tag (e.g., `v1.2.3`) is pushed to the repository. The workflow performs the following steps:
+The deployment workflow is triggered automatically when a new semantic version tag (e.g., `1.2.3`) is pushed to the repository. The workflow performs the following steps:
 1. Checks out the code for the tagged release.
 2. Configures AWS credentials using GitHub Secrets.
-3. Uploads the `schema.json` file to the configured S3 bucket under a directory named after the release tag (e.g., `s3://my-bucket/v1.2.3/schema.json`).
+3. Uploads the `schema.json` file to the configured S3 bucket under a directory named after the release tag (e.g., `s3://my-bucket/1.2.3/schema.json`).
 
 ## Prerequisites
 
@@ -107,8 +107,8 @@ The four secrets expected by the workflow are:
 To trigger a deployment, simply create and push a new tag:
 
 ```bash
-git tag v1.2.3
-git push origin v1.2.3
+git tag 1.2.3
+git push origin 1.2.3
 ```
 
 The workflow will run automatically. You can monitor its progress in the **Actions** tab of the repository.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ This document explains how to set up the automated deployment pipeline for ARDaC
 
 ## Deployment Overview
 
-The deployment workflow is triggered automatically when a new semantic version tag (e.g., `1.2.3`) is pushed to the repository. The workflow performs the following steps:
+The deployment workflow is triggered automatically when a new semantic version tag (e.g., `v1.2.3`) is pushed to the repository. The workflow performs the following steps:
 1. Checks out the code for the tagged release.
 2. Configures AWS credentials using GitHub Secrets.
 3. Uploads the `schema.json` file to the configured S3 bucket under a directory named after the release tag (e.g., `s3://my-bucket/v1.2.3/schema.json`).
@@ -31,10 +31,16 @@ GITHUB_REPO="org/repo"               # e.g. Su-informatics-lab/ardac-dict
 # ─────────────────────────────────────────────────────────────────────────────
 
 # 1. Create the S3 bucket
-aws s3api create-bucket \
+if [ "$AWS_REGION" = "us-east-1" ]; then
+  aws s3api create-bucket \
+    --bucket "$BUCKET_NAME" \
+    --region "$AWS_REGION"
+else
+  aws s3api create-bucket \
     --bucket "$BUCKET_NAME" \
     --region "$AWS_REGION" \
     --create-bucket-configuration LocationConstraint="$AWS_REGION"
+fi
 
 # 2. Create the IAM policy
 POLICY_ARN=$(aws iam create-policy \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,108 @@
+# Deployment Setup
+
+This document explains how to set up the automated deployment pipeline for ARDaC Data Dictionary releases.
+
+## Deployment Overview
+
+The deployment workflow is triggered automatically when a new semantic version tag (e.g., `1.2.3`) is pushed to the repository. The workflow performs the following steps:
+1. Checks out the code for the tagged release.
+2. Configures AWS credentials using GitHub Secrets.
+3. Uploads the `schema.json` file to the configured S3 bucket under a directory named after the release tag (e.g., `s3://my-bucket/v1.2.3/schema.json`).
+
+## Prerequisites
+
+To enable this workflow, you must configure the following:
+
+1. An AWS S3 bucket to host the schema files.
+2. An AWS IAM User with permissions to write to that bucket.
+3. GitHub Secrets with the AWS credentials and configuration.
+
+## AWS Configuration
+
+The following script creates the S3 bucket, IAM policy, and IAM user using the AWS CLI. Set the variables at the top, then run the whole block.
+
+```bash
+# ── Configuration ────────────────────────────────────────────────────────────
+BUCKET_NAME="your-bucket-name"       # e.g. ardac-dictionary-releases
+AWS_REGION="us-east-1"
+USER_NAME="github-actions-deploy"
+POLICY_NAME="ARDaCDictionaryDeployPolicy"
+GITHUB_REPO="org/repo"               # e.g. Su-informatics-lab/ardac-dict
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 1. Create the S3 bucket
+aws s3api create-bucket \
+    --bucket "$BUCKET_NAME" \
+    --region "$AWS_REGION" \
+    --create-bucket-configuration LocationConstraint="$AWS_REGION"
+
+# 2. Create the IAM policy
+POLICY_ARN=$(aws iam create-policy \
+    --policy-name "$POLICY_NAME" \
+    --policy-document "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [{
+            \"Effect\": \"Allow\",
+            \"Action\": \"s3:PutObject\",
+            \"Resource\": \"arn:aws:s3:::${BUCKET_NAME}/*\"
+        }]
+    }" \
+    --query 'Policy.Arn' \
+    --output text)
+
+echo "Policy ARN: $POLICY_ARN"
+
+# 3. Create the IAM user
+aws iam create-user --user-name "$USER_NAME"
+
+# 4. Attach the policy to the user
+aws iam attach-user-policy \
+    --user-name "$USER_NAME" \
+    --policy-arn "$POLICY_ARN"
+
+# 5. Create access keys and capture output
+KEYS=$(aws iam create-access-key \
+    --user-name "$USER_NAME" \
+    --query 'AccessKey.{KeyId:AccessKeyId,Secret:SecretAccessKey}' \
+    --output json)
+
+ACCESS_KEY_ID=$(echo "$KEYS" | python3 -c "import sys,json; print(json.load(sys.stdin)['KeyId'])")
+SECRET_ACCESS_KEY=$(echo "$KEYS" | python3 -c "import sys,json; print(json.load(sys.stdin)['Secret'])")
+
+echo "Access Key ID:     $ACCESS_KEY_ID"
+echo "Secret Access Key: $SECRET_ACCESS_KEY"
+```
+
+> **Important:** Save the `SECRET_ACCESS_KEY` value — it cannot be retrieved again after this step.
+
+## GitHub Configuration
+
+Use the `gh` CLI to add the required secrets to your repository:
+
+```bash
+# Uses the variables set in the AWS Configuration block above
+gh secret set AWS_ACCESS_KEY_ID     --body "$ACCESS_KEY_ID"     --repo "$GITHUB_REPO"
+gh secret set AWS_SECRET_ACCESS_KEY --body "$SECRET_ACCESS_KEY" --repo "$GITHUB_REPO"
+gh secret set AWS_REGION            --body "$AWS_REGION"        --repo "$GITHUB_REPO"
+gh secret set AWS_S3_BUCKET         --body "$BUCKET_NAME"       --repo "$GITHUB_REPO"
+```
+
+The four secrets expected by the workflow are:
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | Access key ID for the `github-actions-deploy` IAM user. |
+| `AWS_SECRET_ACCESS_KEY` | Secret access key for the IAM user. |
+| `AWS_REGION` | AWS region where the S3 bucket lives (e.g., `us-east-1`). |
+| `AWS_S3_BUCKET` | Name of the S3 bucket (e.g., `ardac-dictionary-releases`). |
+
+## Triggering a Deployment
+
+To trigger a deployment, simply create and push a new tag:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow will run automatically. You can monitor its progress in the **Actions** tab of the repository.


### PR DESCRIPTION
- [x] Analyze feedback and plan changes
- [x] Tighten workflow tag trigger to `v[0-9]+.[0-9]+.[0-9]+` (excludes dev/pre-release tags like `2.1.0-jn-new-file-type`)
- [x] Remove unnecessary `id-token: write` permission (workflow uses static AWS keys)
- [x] Fix `docs/deployment.md` tag format to consistently use `v1.2.3`
- [x] Fix `create-bucket` command for `us-east-1` in `docs/deployment.md`