### PR TITLE
Fix typo in comments

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -3,7 +3,7 @@ name: Deploy Release to S3
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'   # Release tags only (e.g., v1.2.3) — excludes dev/pre-release tags
+      - '[0-9]+.[0-9]+.[0-9]+'   # Release tags only (e.g., 1.2.3) — excludes dev/pre-release tags
 
 permissions:
   contents: read    # This is required for actions/checkout


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration. The tag pattern comment in `.github/workflows/deploy-release.yml` was corrected to accurately reflect the release tag format (e.g., `1.2.3` instead of `v1.2.3`).