### PR TITLE
Release 2.3.0

### DIFF
--- a/gdcdictionary/schemas/experimental_metadata.yaml
+++ b/gdcdictionary/schemas/experimental_metadata.yaml
@@ -108,7 +108,7 @@ properties:
     - string
     - 'null'
   experiments:
-    $ref: _definitions.yaml#/to_one
+    $ref: _definitions.yaml#/to_many
   core_metadata_collections:
     $ref: _definitions.yaml#/to_many
   labs:

--- a/gdcdictionary/schemas/experimental_metadata.yaml
+++ b/gdcdictionary/schemas/experimental_metadata.yaml
@@ -6,7 +6,8 @@ namespace: http://gdc.nci.nih.gov
 category: metadata_file
 project: '*'
 program: '*'
-description: 'Data file containing the metadata for the experiment performed.
+description: 'Data file containing the metadata for the experiment performed, or
+  processed quantification data (e.g. proteomics) produced by a lab.
 
   '
 additionalProperties: false
@@ -36,6 +37,12 @@ links:
     target_type: experiment
     multiplicity: many_to_many
     required: false
+  - name: labs
+    backref: experiment_metadata_files
+    label: produced_by
+    target_type: lab
+    multiplicity: many_to_one
+    required: false
 required:
 - submitter_id
 - type
@@ -64,12 +71,45 @@ properties:
       $ref: _terms.yaml#/data_type
     enum:
     - Experimental Metadata
+    - Proteomics Quantification
   data_format:
     term:
       $ref: _terms.yaml#/data_format
     type:
     - string
+  experimental_strategy:
+    term:
+      $ref: _terms.yaml#/experimental_strategy
+    description: The experimental strategy used to generate the data file.
+    enum:
+    - LC-MS/MS
+    - TMT
+    - Label-Free
+    - DIA
+    - DDA
+    - SWATH
+  measurement_type:
+    description: The type of quantification measurement in the data file.
+    enum:
+    - pep
+    - Quantity
+    - Spectral_Count
+    - iBAQ
+  instrument_model:
+    description: The model of mass spectrometry instrument used (e.g. Orbitrap Exploris
+      480).
+    type:
+    - string
+    - 'null'
+  software_version:
+    description: The software and version used for data processing (e.g. MaxQuant
+      2.1.0).
+    type:
+    - string
+    - 'null'
   experiments:
     $ref: _definitions.yaml#/to_one
   core_metadata_collections:
     $ref: _definitions.yaml#/to_many
+  labs:
+    $ref: _definitions.yaml#/to_one

--- a/schema.json
+++ b/schema.json
@@ -1259,7 +1259,7 @@
                 ]
             },
             "experiments": {
-                "$ref": "_definitions.yaml#/to_one"
+                "$ref": "_definitions.yaml#/to_many"
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "ac64238dbb1d0c5226adba3a2e56e453c69892a2",
-        "_dict_version": "2.3.0-experimental-metadata-update"
+        "_dict_commit": "8e1d88b566153981597965e8d826adef95080271",
+        "_dict_version": "2.3.0"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "ea88151660d32cd4e7950eaa4496924758f4e5d1",
-        "_dict_version": "2.2.3"
+        "_dict_commit": "ac64238dbb1d0c5226adba3a2e56e453c69892a2",
+        "_dict_version": "2.3.0-experimental-metadata-update"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1125,7 +1125,7 @@
         "category": "metadata_file",
         "project": "*",
         "program": "*",
-        "description": "Data file containing the metadata for the experiment performed.\n",
+        "description": "Data file containing the metadata for the experiment performed, or processed quantification data (e.g. proteomics) produced by a lab.\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -1157,6 +1157,14 @@
                         "label": "derived_from",
                         "target_type": "experiment",
                         "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "labs",
+                        "backref": "experiment_metadata_files",
+                        "label": "produced_by",
+                        "target_type": "lab",
+                        "multiplicity": "many_to_one",
                         "required": false
                     }
                 ]
@@ -1201,7 +1209,8 @@
                     "$ref": "_terms.yaml#/data_type"
                 },
                 "enum": [
-                    "Experimental Metadata"
+                    "Experimental Metadata",
+                    "Proteomics Quantification"
                 ]
             },
             "data_format": {
@@ -1212,11 +1221,51 @@
                     "string"
                 ]
             },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "description": "The experimental strategy used to generate the data file.",
+                "enum": [
+                    "LC-MS/MS",
+                    "TMT",
+                    "Label-Free",
+                    "DIA",
+                    "DDA",
+                    "SWATH"
+                ]
+            },
+            "measurement_type": {
+                "description": "The type of quantification measurement in the data file.",
+                "enum": [
+                    "pep",
+                    "Quantity",
+                    "Spectral_Count",
+                    "iBAQ"
+                ]
+            },
+            "instrument_model": {
+                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "software_version": {
+                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
             "experiments": {
                 "$ref": "_definitions.yaml#/to_one"
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
             }
         }
     },


### PR DESCRIPTION
## Release 2.3.0

### Changes
Updates the `experimental_metadata` schema with proteomics support:

- **New link**: `labs` (produced_by, many_to_one) — associates experimental metadata files with a lab
- **Updated description**: now mentions processed quantification data (e.g. proteomics)
- **New `data_type` enum value**: `Proteomics Quantification`
- **New properties**:
  - experimental_strategy: enum (LC-MS/MS, TMT, Label-Free, DIA, DDA, SWATH)
  - measurement_type: enum (pep, Quantity, Spectral_Count, iBAQ)
  - instrument_mode\: free-text string (nullable)
  - software_version: free-text string (nullable)

### Validation
All 20 dictutils tests pass. `schema.json` regenerated with tag `2.3.0`.