### PR TITLE
Release 2.4.0

### DIFF
--- a/gdcdictionary/schemas/experimental_metadata.yaml
+++ b/gdcdictionary/schemas/experimental_metadata.yaml
@@ -6,7 +6,8 @@ namespace: http://gdc.nci.nih.gov
 category: metadata_file
 project: '*'
 program: '*'
-description: 'Data file containing the metadata for the experiment performed.
+description: 'Data file containing the metadata for the experiment performed, or
+  processed quantification data (e.g. proteomics) produced by a lab.
 
   '
 additionalProperties: false
@@ -36,6 +37,12 @@ links:
     target_type: experiment
     multiplicity: many_to_many
     required: false
+  - name: labs
+    backref: experiment_metadata_files
+    label: produced_by
+    target_type: lab
+    multiplicity: many_to_one
+    required: false
 required:
 - submitter_id
 - type
@@ -64,12 +71,45 @@ properties:
       $ref: _terms.yaml#/data_type
     enum:
     - Experimental Metadata
+    - Proteomics Quantification
   data_format:
     term:
       $ref: _terms.yaml#/data_format
     type:
     - string
+  experimental_strategy:
+    term:
+      $ref: _terms.yaml#/experimental_strategy
+    description: The experimental strategy used to generate the data file.
+    enum:
+    - LC-MS/MS
+    - TMT
+    - Label-Free
+    - DIA
+    - DDA
+    - SWATH
+  measurement_type:
+    description: The type of quantification measurement in the data file.
+    enum:
+    - pep
+    - Quantity
+    - Spectral_Count
+    - iBAQ
+  instrument_model:
+    description: The model of mass spectrometry instrument used (e.g. Orbitrap Exploris
+      480).
+    type:
+    - string
+    - 'null'
+  software_version:
+    description: The software and version used for data processing (e.g. MaxQuant
+      2.1.0).
+    type:
+    - string
+    - 'null'
   experiments:
     $ref: _definitions.yaml#/to_one
   core_metadata_collections:
     $ref: _definitions.yaml#/to_many
+  labs:
+    $ref: _definitions.yaml#/to_one

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -9,14 +9,16 @@ program: '*'
 description: Data file containing proteomics data.
 additionalProperties: false
 submittable: true
+downloadable: true
+previous_version_downloadable: true
 validators: null
 systemProperties:
 - id
 - project_id
 - created_datetime
 - updated_datetime
-- file_state
 - state
+- file_state
 - error_type
 links:
 - exclusive: false
@@ -41,14 +43,17 @@ required:
 - file_size
 - md5sum
 - data_category
-- data_format
 - data_type
+- data_format
 uniqueKeys:
 - - id
 - - project_id
   - submitter_id
 properties:
   $ref: _definitions.yaml#/data_file_properties
+  type:
+    enum:
+    - protein_expression
   data_category:
     term:
       $ref: _terms.yaml#/data_category
@@ -67,6 +72,7 @@ properties:
   experimental_strategy:
     term:
       $ref: _terms.yaml#/experimental_strategy
+    description: The experimental strategy used to generate the data file.
     enum:
     - Reverse Phase Protein Array
     - LC-MS/MS

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -1,0 +1,106 @@
+$schema: http://json-schema.org/draft-04/schema#
+id: protein_expression
+title: Protein Expression
+type: object
+namespace: https://gdc.cancer.gov
+category: data_file
+project: '*'
+program: '*'
+description: Data file containing proteomics data.
+additionalProperties: false
+submittable: true
+validators: null
+systemProperties:
+- id
+- project_id
+- created_datetime
+- updated_datetime
+- file_state
+- state
+- error_type
+links:
+- exclusive: false
+  required: true
+  subgroup:
+  - name: core_metadata_collections
+    backref: protein_expressions
+    label: data_from
+    target_type: core_metadata_collection
+    multiplicity: many_to_many
+    required: false
+  - name: labs
+    backref: protein_expressions
+    label: produced_by
+    target_type: lab
+    multiplicity: many_to_one
+    required: false
+required:
+- submitter_id
+- type
+- file_name
+- file_size
+- md5sum
+- data_category
+- data_format
+- data_type
+uniqueKeys:
+- - id
+- - project_id
+  - submitter_id
+properties:
+  $ref: _definitions.yaml#/data_file_properties
+  data_category:
+    term:
+      $ref: _terms.yaml#/data_category
+    type:
+    - string
+  data_type:
+    term:
+      $ref: _terms.yaml#/data_type
+    type:
+    - string
+  data_format:
+    term:
+      $ref: _terms.yaml#/data_format
+    type:
+    - string
+  experimental_strategy:
+    term:
+      $ref: _terms.yaml#/experimental_strategy
+    enum:
+    - Reverse Phase Protein Array
+    - LC-MS/MS
+    - TMT
+    - Label-Free
+    - DIA
+    - DDA
+    - SWATH
+  platform:
+    term:
+      $ref: _terms.yaml#/platform
+    type:
+    - string
+    - 'null'
+  measurement_type:
+    description: The type of quantification measurement in the data file.
+    enum:
+    - pep
+    - Quantity
+    - Spectral_Count
+    - iBAQ
+  instrument_model:
+    description: The model of mass spectrometry instrument used (e.g. Orbitrap Exploris
+      480).
+    type:
+    - string
+    - 'null'
+  software_version:
+    description: The software and version used for data processing (e.g. MaxQuant
+      2.1.0).
+    type:
+    - string
+    - 'null'
+  core_metadata_collections:
+    $ref: _definitions.yaml#/to_many
+  labs:
+    $ref: _definitions.yaml#/to_one

--- a/gdcdictionary/schemas/protein_expression.yaml
+++ b/gdcdictionary/schemas/protein_expression.yaml
@@ -1,0 +1,114 @@
+$schema: http://json-schema.org/draft-04/schema#
+id: protein_expression
+title: Protein Expression
+type: object
+namespace: https://gdc.cancer.gov
+category: data_file
+project: '*'
+program: '*'
+description: 'Data file containing proteomics data.
+
+  '
+additionalProperties: false
+submittable: true
+downloadable: true
+previous_version_downloadable: true
+validators: null
+systemProperties:
+- id
+- project_id
+- created_datetime
+- updated_datetime
+- state
+- file_state
+- error_type
+links:
+- exclusive: false
+  required: true
+  subgroup:
+  - name: core_metadata_collections
+    backref: protein_expressions
+    label: data_from
+    target_type: core_metadata_collection
+    multiplicity: many_to_many
+    required: false
+  - name: labs
+    backref: protein_expressions
+    label: produced_by
+    target_type: lab
+    multiplicity: many_to_one
+    required: false
+required:
+- submitter_id
+- type
+- file_name
+- file_size
+- md5sum
+- data_category
+- data_type
+- data_format
+uniqueKeys:
+- - id
+- - project_id
+  - submitter_id
+properties:
+  $ref: _definitions.yaml#/data_file_properties
+  type:
+    enum:
+    - protein_expression
+  data_category:
+    term:
+      $ref: _terms.yaml#/data_category
+    type:
+    - string
+  data_type:
+    term:
+      $ref: _terms.yaml#/data_type
+    type:
+    - string
+  data_format:
+    term:
+      $ref: _terms.yaml#/data_format
+    type:
+    - string
+  experimental_strategy:
+    term:
+      $ref: _terms.yaml#/experimental_strategy
+    description: The experimental strategy used to generate the data file.
+    enum:
+    - Reverse Phase Protein Array
+    - LC-MS/MS
+    - TMT
+    - Label-Free
+    - DIA
+    - DDA
+    - SWATH
+  platform:
+    term:
+      $ref: _terms.yaml#/platform
+    type:
+    - string
+    - 'null'
+  measurement_type:
+    description: The type of quantification measurement in the data file.
+    enum:
+    - pep
+    - Quantity
+    - Spectral_Count
+    - iBAQ
+  instrument_model:
+    description: The model of mass spectrometry instrument used (e.g. Orbitrap Exploris
+      480).
+    type:
+    - string
+    - 'null'
+  software_version:
+    description: The software and version used for data processing (e.g. MaxQuant
+      2.1.0).
+    type:
+    - string
+    - 'null'
+  core_metadata_collections:
+    $ref: _definitions.yaml#/to_many
+  labs:
+    $ref: _definitions.yaml#/to_one

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "ac64238dbb1d0c5226adba3a2e56e453c69892a2",
-        "_dict_version": "2.3.0-experimental-metadata-update"
+        "_dict_commit": "42998b09353dffbe78f8edb75a8a23d55e3cd9d8",
+        "_dict_version": "2.4.0-protein-expression"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1259,7 +1259,7 @@
                 ]
             },
             "experiments": {
-                "$ref": "_definitions.yaml#/to_one"
+                "$ref": "_definitions.yaml#/to_many"
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
@@ -9470,6 +9470,151 @@
             },
             "submitted_aligned_reads_files": {
                 "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "protein_expression.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "protein_expression",
+        "title": "Protein Expression",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing proteomics data.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "protein_expressions",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "labs",
+                        "backref": "protein_expressions",
+                        "label": "produced_by",
+                        "target_type": "lab",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "Reverse Phase Protein Array",
+                    "LC-MS/MS",
+                    "TMT",
+                    "Label-Free",
+                    "DIA",
+                    "DDA",
+                    "SWATH"
+                ]
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "measurement_type": {
+                "description": "The type of quantification measurement in the data file.",
+                "enum": [
+                    "pep",
+                    "Quantity",
+                    "Spectral_Count",
+                    "iBAQ"
+                ]
+            },
+            "instrument_model": {
+                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "software_version": {
+                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
             }
         }
     },

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "ea88151660d32cd4e7950eaa4496924758f4e5d1",
-        "_dict_version": "2.2.3"
+        "_dict_commit": "ac64238dbb1d0c5226adba3a2e56e453c69892a2",
+        "_dict_version": "2.3.0-experimental-metadata-update"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -1125,7 +1125,7 @@
         "category": "metadata_file",
         "project": "*",
         "program": "*",
-        "description": "Data file containing the metadata for the experiment performed.\n",
+        "description": "Data file containing the metadata for the experiment performed, or processed quantification data (e.g. proteomics) produced by a lab.\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -1157,6 +1157,14 @@
                         "label": "derived_from",
                         "target_type": "experiment",
                         "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "labs",
+                        "backref": "experiment_metadata_files",
+                        "label": "produced_by",
+                        "target_type": "lab",
+                        "multiplicity": "many_to_one",
                         "required": false
                     }
                 ]
@@ -1201,7 +1209,8 @@
                     "$ref": "_terms.yaml#/data_type"
                 },
                 "enum": [
-                    "Experimental Metadata"
+                    "Experimental Metadata",
+                    "Proteomics Quantification"
                 ]
             },
             "data_format": {
@@ -1212,11 +1221,51 @@
                     "string"
                 ]
             },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "description": "The experimental strategy used to generate the data file.",
+                "enum": [
+                    "LC-MS/MS",
+                    "TMT",
+                    "Label-Free",
+                    "DIA",
+                    "DDA",
+                    "SWATH"
+                ]
+            },
+            "measurement_type": {
+                "description": "The type of quantification measurement in the data file.",
+                "enum": [
+                    "pep",
+                    "Quantity",
+                    "Spectral_Count",
+                    "iBAQ"
+                ]
+            },
+            "instrument_model": {
+                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "software_version": {
+                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
             "experiments": {
                 "$ref": "_definitions.yaml#/to_one"
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
             }
         }
     },

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "42998b09353dffbe78f8edb75a8a23d55e3cd9d8",
-        "_dict_version": "2.4.0-protein-expression"
+        "_dict_commit": "10de04adee6e32dd96aa53ccbebebc045a9a6328",
+        "_dict_version": "2.4.0"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -9485,14 +9485,16 @@
         "description": "Data file containing proteomics data.",
         "additionalProperties": false,
         "submittable": true,
+        "downloadable": true,
+        "previous_version_downloadable": true,
         "validators": null,
         "systemProperties": [
             "id",
             "project_id",
             "created_datetime",
             "updated_datetime",
-            "file_state",
             "state",
+            "file_state",
             "error_type"
         ],
         "links": [
@@ -9526,8 +9528,8 @@
             "file_size",
             "md5sum",
             "data_category",
-            "data_format",
-            "data_type"
+            "data_type",
+            "data_format"
         ],
         "uniqueKeys": [
             [
@@ -9540,6 +9542,11 @@
         ],
         "properties": {
             "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "protein_expression"
+                ]
+            },
             "data_category": {
                 "term": {
                     "$ref": "_terms.yaml#/data_category"
@@ -9568,6 +9575,7 @@
                 "term": {
                     "$ref": "_terms.yaml#/experimental_strategy"
                 },
+                "description": "The experimental strategy used to generate the data file.",
                 "enum": [
                     "Reverse Phase Protein Array",
                     "LC-MS/MS",

--- a/schema.json
+++ b/schema.json
@@ -221,8 +221,8 @@
     },
     "_settings.yaml": {
         "enable_case_cache": false,
-        "_dict_commit": "42998b09353dffbe78f8edb75a8a23d55e3cd9d8",
-        "_dict_version": "2.4.0-protein-expression"
+        "_dict_commit": "10de04adee6e32dd96aa53ccbebebc045a9a6328",
+        "_dict_version": "2.4.0"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",

--- a/schema.json
+++ b/schema.json
@@ -1,95 +1,14 @@
 {
-    "acknowledgement.yaml": {
+    "aligned_reads_index.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "acknowledgement",
-        "title": "Acknowledgement",
+        "id": "aligned_reads_index",
+        "title": "Aligned Reads Index",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
-        "category": "administrative",
+        "category": "index_file",
         "program": "*",
         "project": "*",
-        "description": "Acknowledgement of an individual involved in a project.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "links": [
-            {
-                "name": "projects",
-                "backref": "acknowledgements",
-                "label": "contribute_to",
-                "target_type": "project",
-                "multiplicity": "many_to_many",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "acknowledgement"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "acknowledgee": {
-                "description": "The indvidiual or group being acknowledged by the project.",
-                "type": "string"
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_many_project"
-            },
-            "project_id": {
-                "type": "string"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "submitted_aligned_reads.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_aligned_reads",
-        "title": "Submitted Aligned Reads",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "data_file",
-        "program": "*",
-        "project": "*",
-        "description": "Data file containing aligned reads that are used as input to GDC workflows.\n",
+        "description": "Data file containing the index for a set of aligned reads.",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -108,16 +27,16 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "read_groups",
-                        "backref": "submitted_aligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "read_group",
-                        "multiplicity": "one_to_many",
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "aligned_reads_indexes",
+                        "label": "derived_from",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "one_to_one",
                         "required": false
                     },
                     {
                         "name": "core_metadata_collections",
-                        "backref": "submitted_aligned_reads_files",
+                        "backref": "aligned_reads_indexes",
                         "label": "data_from",
                         "target_type": "core_metadata_collection",
                         "multiplicity": "many_to_many",
@@ -131,11 +50,10 @@
             "type",
             "file_name",
             "file_size",
-            "data_format",
             "md5sum",
             "data_category",
             "data_type",
-            "experimental_strategy"
+            "data_format"
         ],
         "uniqueKeys": [
             [
@@ -150,7 +68,7 @@
             "$ref": "_definitions.yaml#/data_file_properties",
             "type": {
                 "enum": [
-                    "submitted_aligned_reads"
+                    "aligned_reads_index"
                 ]
             },
             "data_category": {
@@ -168,61 +86,26 @@
                     "$ref": "_terms.yaml#/data_type"
                 },
                 "enum": [
-                    "Aligned Reads",
-                    "Alignment Coordinates"
+                    "Aligned Reads Index"
                 ]
             },
             "data_format": {
                 "term": {
                     "$ref": "_terms.yaml#/data_format"
                 },
+                "description": "UPDATED: Format of the data files.",
                 "enum": [
-                    "BAM",
-                    "BED",
-                    "CRAM"
+                    "BAI",
+                    "CRAI"
                 ]
             },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "Low Pass WGS",
-                    "Validation",
-                    "RNA-Seq",
-                    "miRNA-Seq",
-                    "Total RNA-Seq",
-                    "DNA Panel",
-                    "ATAC-Seq",
-                    "Bisulfite-Seq",
-                    "ChIP-Seq",
-                    "HiChIP",
-                    "m6A MeRIP-Seq",
-                    "scATAC-Seq",
-                    "scRNA-Seq",
-                    "Targeted Sequencing"
-                ]
-            },
-            "proc_internal": {
-                "description": "NEW: Internal data processing flag.",
-                "enum": [
-                    "dna-seq skip"
-                ]
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_many"
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_one"
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
             }
         }
-    },
-    "_settings.yaml": {
-        "enable_case_cache": false,
-        "_dict_commit": "8e1d88b566153981597965e8d826adef95080271",
-        "_dict_version": "2.3.0"
     },
     "treatment.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -469,6 +352,2429 @@
             },
             "updated_datetime": {
                 "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "program.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "program",
+        "title": "Program",
+        "type": "object",
+        "category": "administrative",
+        "program": "*",
+        "project": "*",
+        "description": "A broad framework of goals to be achieved. (NCIt C52647)\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id"
+        ],
+        "required": [
+            "name",
+            "dbgap_accession_number"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "name"
+            ]
+        ],
+        "links": [],
+        "properties": {
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "name": {
+                "type": "string",
+                "description": "Full name/title of the program."
+            },
+            "dbgap_accession_number": {
+                "type": "string",
+                "description": "The dbgap accession number provided for the program."
+            }
+        }
+    },
+    "read_group_qc.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "read_group_qc",
+        "title": "Read Group QC",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "notation",
+        "project": "*",
+        "program": "*",
+        "description": "GDC QC run metadata.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "read_group_qcs",
+                        "label": "data_from",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_unaligned_reads_files",
+                        "backref": "read_group_qcs",
+                        "label": "data_from",
+                        "target_type": "submitted_unaligned_reads",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "name": "read_groups",
+                "label": "generated_from",
+                "target_type": "read_group",
+                "multiplicity": "many_to_one",
+                "required": true,
+                "backref": "read_group_qcs"
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "workflow_link",
+            "type",
+            "percent_gc_content",
+            "encoding",
+            "total_sequences",
+            "basic_statistics",
+            "per_base_sequence_quality",
+            "per_tile_sequence_quality",
+            "per_sequence_quality_score",
+            "per_base_sequence_content",
+            "per_sequence_gc_content",
+            "per_base_n_content",
+            "sequence_length_distribution",
+            "sequence_duplication_levels",
+            "overrepresented_sequences",
+            "adapter_content",
+            "kmer_content",
+            "read_groups"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "type": {
+                "enum": [
+                    "read_group_qc"
+                ]
+            },
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "Read Group Quality Control"
+                ]
+            },
+            "fastq_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/file_name"
+                },
+                "type": "string"
+            },
+            "percent_aligned": {
+                "description": "The percent of reads with at least one reported alignment.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100
+            },
+            "percent_gc_content": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_gc_content"
+                },
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100
+            },
+            "encoding": {
+                "term": {
+                    "$ref": "_terms.yaml#/encoding"
+                },
+                "type": "string"
+            },
+            "total_aligned_reads": {
+                "description": "The total number of reads with at least one reported alignment.",
+                "type": "integer"
+            },
+            "total_sequences": {
+                "term": {
+                    "$ref": "_terms.yaml#/total_sequences"
+                },
+                "type": "integer"
+            },
+            "basic_statistics": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_base_sequence_quality": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_tile_sequence_quality": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_sequence_quality_score": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_base_sequence_content": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_sequence_gc_content": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "per_base_n_content": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "sequence_length_distribution": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "sequence_duplication_levels": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "overrepresented_sequences": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "adapter_content": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "kmer_content": {
+                "$ref": "_definitions.yaml#/qc_metrics_state"
+            },
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "submitted_unaligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "submitted_unaligned_reads.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "submitted_unaligned_reads",
+        "title": "Submitted Unaligned Reads",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "data_file",
+        "program": "*",
+        "project": "*",
+        "description": "Data file containing unaligned reads that have not been GDC Harmonized.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "read_groups",
+                        "backref": "submitted_unaligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "read_group",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_unaligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format",
+            "experimental_strategy"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "submitted_unaligned_reads"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Sequencing Data",
+                    "Sequencing Reads",
+                    "Raw Sequencing Data"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Unaligned Reads"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "BAM",
+                    "FASTQ"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "description": "UPDATED: The sequencing strategy used to generate the data file.",
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "Low Pass WGS",
+                    "Validation",
+                    "RNA-Seq",
+                    "miRNA-Seq",
+                    "Total RNA-Seq",
+                    "DNA Panel",
+                    "ATAC-Seq",
+                    "Bisulfite-Seq",
+                    "ChIP-Seq",
+                    "HiChIP",
+                    "m6A MeRIP-Seq",
+                    "scATAC-Seq",
+                    "scRNA-Seq",
+                    "Targeted Sequencing"
+                ]
+            },
+            "read_pair_number": {
+                "description": "NEW: Denotes whether a submitted FASTQ file contains forward (R1) or reverse (R2) reads for paired-end sequencing.",
+                "enum": [
+                    "R1",
+                    "R2",
+                    "R3",
+                    "Not Applicable"
+                ]
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "slide_count.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "slide_count",
+        "title": "Slide Count",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "notation",
+        "program": "*",
+        "project": "*",
+        "description": "Information pertaining to processed results obtained from slides; often in the form of counts.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "name": "slides",
+                "backref": "slide_counts",
+                "label": "data_from",
+                "target_type": "slide",
+                "multiplicity": "many_to_many",
+                "required": true
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "slides"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "enum": [
+                    "slide_count"
+                ]
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "cell_type": {
+                "description": "The type of cell being counted or measured.",
+                "type": "string"
+            },
+            "cell_identifier": {
+                "description": "An alternative identifier for a given cell type.",
+                "type": "string"
+            },
+            "cell_count": {
+                "description": "Raw count of a particular cell type.",
+                "type": "integer"
+            },
+            "ck_signal": {
+                "description": "Numeric quantification of the CK signal.",
+                "type": "number"
+            },
+            "biomarker_signal": {
+                "description": "Numeric quantification of the biomarker signal.",
+                "type": "number"
+            },
+            "er_localization": {
+                "description": "Cellular localization of the endoplasmic reticulum as determined by staining.",
+                "enum": [
+                    "Nuclear",
+                    "Cytoplasmic",
+                    "Both",
+                    "None",
+                    "Not Determined"
+                ]
+            },
+            "frame_identifier": {
+                "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
+                "type": "string"
+            },
+            "relative_nuclear_size": {
+                "description": "The ratio of the single cell's nucleus size to the average of the surrounding cells.",
+                "type": "number"
+            },
+            "relative_nuclear_intensity": {
+                "description": "The ratio of the single cell's nuclear staining intensity to the average of the surrounding cells.",
+                "type": "number"
+            },
+            "relative_cytokeratin_intensity": {
+                "description": "The ratio of the single cell's cytokeratin staining intensity to the average of the surrounding cells.",
+                "type": "number"
+            },
+            "relative_er_intensity": {
+                "description": "The ratio of the single cell's endoplasmic reticulum staining intensity to the average of the surrounding cells.",
+                "type": "number"
+            },
+            "run_name": {
+                "description": "The name or identifier given to the run that was used to generate this slide count.",
+                "type": "string"
+            },
+            "slides": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "project_id": {
+                "type": "string"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "slide.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "slide",
+        "title": "Slide",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "biospecimen",
+        "program": "*",
+        "project": "*",
+        "description": "A digital image, microscopic or otherwise, of any sample, portion, or sub-part thereof. (GDC)\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "links": [
+            {
+                "name": "samples",
+                "backref": "slides",
+                "label": "derived_from",
+                "target_type": "sample",
+                "multiplicity": "many_to_many",
+                "required": true
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "samples"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "apoptotic_concentration": {
+                "description": "The concentration, in cells/mL, of apoptotic cells in the slide blood.",
+                "type": "number"
+            },
+            "ctc_concentration": {
+                "description": "The concentration, in cells/mL, of traditional CTC cells (intact and enlarged cell and nucleus, cytokeratin positive, and CD45 negative) in the slide blood.",
+                "type": "number"
+            },
+            "ctc_low_concentration": {
+                "description": "The concentration, in cells/mL, of CTC-low cells (those with low cytokeratin levels compared to traditional CTCs) in the slide blood.",
+                "type": "number"
+            },
+            "ctc_small_concentration": {
+                "description": "The concentration, in cells/mL, of CTC-small cells (those with a small nuclear and cellular size relative to traditional CTCs) in the slide blood.",
+                "type": "number"
+            },
+            "section_location": {
+                "term": {
+                    "$ref": "_terms.yaml#/section_location"
+                },
+                "type": "string"
+            },
+            "methanol_added": {
+                "description": "True/False indicator for if methanol was used in the slide preparation process.",
+                "type": "boolean"
+            },
+            "number_proliferating_cells": {
+                "term": {
+                    "$ref": "_terms.yaml#/number_proliferating_cells"
+                },
+                "type": "integer"
+            },
+            "number_nucleated_cells": {
+                "description": "The total number of nucleated cells identified on the slide.",
+                "type": "integer"
+            },
+            "percent_tumor_cells": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_tumor_cells"
+                },
+                "type": "number"
+            },
+            "percent_tumor_nuclei": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_tumor_nuclei"
+                },
+                "type": "number"
+            },
+            "percent_normal_cells": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_normal_cells"
+                },
+                "type": "number"
+            },
+            "percent_necrosis": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_necrosis"
+                },
+                "type": "number"
+            },
+            "percent_stromal_cells": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_stromal_cells"
+                },
+                "type": "number"
+            },
+            "percent_inflam_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_inflam_infiltration"
+                },
+                "type": "number"
+            },
+            "percent_lymphocyte_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_lymphocyte_infiltration"
+                },
+                "type": "number"
+            },
+            "percent_monocyte_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_monocyte_infiltration"
+                },
+                "type": "number"
+            },
+            "percent_granulocyte_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_granulocyte_infiltration"
+                },
+                "type": "number"
+            },
+            "percent_neutrophil_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_neutrophil_infiltration"
+                },
+                "type": "number"
+            },
+            "percent_eosinophil_infiltration": {
+                "term": {
+                    "$ref": "_terms.yaml#/percent_eosinophil_infiltration"
+                },
+                "type": "number"
+            },
+            "run_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "run_name": {
+                "description": "Name, number, or other identifier given to this slide's run.",
+                "type": "string"
+            },
+            "slide_identifier": {
+                "description": "Unique identifier given to the this slide.",
+                "type": "string"
+            },
+            "samples": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "slide_image.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "slide_image",
+        "title": "Slide Image",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "data_file",
+        "program": "*",
+        "project": "*",
+        "description": "Data file containing image of a slide.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "slides",
+                        "backref": "slide_images",
+                        "label": "data_from",
+                        "target_type": "slide",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "slide_images",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "slide_image"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Biospecimen",
+                    "Slide Image",
+                    "Mass Cytometry"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "image",
+                    "Single Cell Image",
+                    "Raw IMC Data",
+                    "Single Channel IMC Image",
+                    "Antibody Panel Added"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": "string"
+            },
+            "experimental_strategy": {
+                "description": "Classification of the slide type with respect to its experimental use.",
+                "enum": [
+                    "Diagnostic Slide",
+                    "Tissue Slide"
+                ]
+            },
+            "cell_type": {
+                "description": "The type of cell being imaged or otherwised analysed.",
+                "type": "string"
+            },
+            "cell_identifier": {
+                "description": "An alternative identifier for a given cell type.",
+                "type": "string"
+            },
+            "cell_count": {
+                "description": "Count of the cell type being imaged or otherwise analysed.",
+                "type": "integer"
+            },
+            "frame_identifier": {
+                "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
+                "type": "string"
+            },
+            "panel_used": {
+                "description": "Name or other identifier given to the panel used during an IMC run.",
+                "type": "string"
+            },
+            "protocol_used": {
+                "description": "Name or other identifier given to the protocol used during an IMC run.",
+                "type": "string"
+            },
+            "run_name": {
+                "description": "Name, number, or other identifier given to the run that generated this slide image.",
+                "type": "string"
+            },
+            "slides": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "publication.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "publication",
+        "title": "Publication",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "administrative",
+        "program": "*",
+        "project": "*",
+        "description": "Publication for a project.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "links": [
+            {
+                "name": "projects",
+                "backref": "publications",
+                "label": "refers_to",
+                "target_type": "project",
+                "multiplicity": "many_to_many",
+                "required": true
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "projects"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "enum": [
+                    "publication"
+                ]
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "pmid": {
+                "type": "string"
+            },
+            "doi": {
+                "type": "string"
+            },
+            "projects": {
+                "$ref": "_definitions.yaml#/to_many_project"
+            },
+            "project_id": {
+                "type": "string"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "read_group.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "read_group",
+        "title": "Read Group",
+        "type": "object",
+        "description": "Sequencing reads from one lane of an NGS experiment.",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "biospecimen",
+        "project": "*",
+        "program": "*",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "name": "aliquots",
+                "label": "derived_from",
+                "target_type": "aliquot",
+                "multiplicity": "many_to_one",
+                "required": true,
+                "backref": "read_groups"
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "aliquots"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "id": {
+                "$ref": "_definitions.yaml#/UUID"
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "submitter_id": {
+                "type": "string"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "type": {
+                "enum": [
+                    "read_group"
+                ]
+            },
+            "experiment_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/experiment_name"
+                },
+                "description": "Submitter-defined name for the experiment.",
+                "type": "string"
+            },
+            "sequencing_center": {
+                "term": {
+                    "$ref": "_terms.yaml#/sequencing_center"
+                },
+                "type": "string"
+            },
+            "sequencing_date": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "description": "Name of the platform used to obtain data.",
+                "enum": [
+                    "Illumina",
+                    "SOLiD",
+                    "LS454",
+                    "Ion Torrent",
+                    "Complete Genomics",
+                    "PacBio",
+                    "Other"
+                ]
+            },
+            "instrument_model": {
+                "terms": {
+                    "$ref": "_terms.yaml#/instrument_model"
+                },
+                "description": "Specific model of sequencing instrument used.",
+                "enum": [
+                    "454 GS FLX Titanium",
+                    "AB SOLiD 4",
+                    "AB SOLiD 2",
+                    "AB SOLiD 3",
+                    "Complete Genomics",
+                    "Illumina HiSeq X Ten",
+                    "Illumina HiSeq X Five",
+                    "Illumina Genome Analyzer II",
+                    "Illumina Genome Analyzer IIx",
+                    "Illumina HiSeq 2000",
+                    "Illumina HiSeq 2500",
+                    "Illumina HiSeq 4000",
+                    "Illumina NovaSeq 6000",
+                    "Illumina MiSeq",
+                    "Illumina NextSeq",
+                    "Ion Torrent PGM",
+                    "Ion Torrent Proton",
+                    "Ion Torrent S5",
+                    "PacBio RS",
+                    "Ion S5 XL System, Ion 530 Chip",
+                    "Other",
+                    "Unknown",
+                    "Not Reported"
+                ]
+            },
+            "library_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_strategy"
+                },
+                "description": "Library strategy.",
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "RNA-Seq",
+                    "ChIP-Seq",
+                    "miRNA-Seq",
+                    "Bisulfite-Seq",
+                    "Validation",
+                    "Amplicon",
+                    "Other",
+                    "ATAC-Seq",
+                    "m6A MeRIP-Seq",
+                    "scATAC-Seq",
+                    "scRNA-Seq",
+                    "Targeted Sequencing",
+                    "DNA-Seq"
+                ]
+            },
+            "RIN": {
+                "term": {
+                    "$ref": "_terms.yaml#/RIN"
+                },
+                "description": "A numerical assessment of the integrity of RNA based on the entire electrophoretic trace of the RNA sample including the presence or absence of degradation products.",
+                "type": "number"
+            },
+            "flow_cell_barcode": {
+                "term": {
+                    "$ref": "_terms.yaml#/flow_cell_barcode"
+                },
+                "description": "Flow cell barcode. Wrong or missing information may affect analysis results.",
+                "type": "string"
+            },
+            "includes_spike_ins": {
+                "term": {
+                    "$ref": "_terms.yaml#/includes_spike_ins"
+                },
+                "description": "Spike-in",
+                "type": "boolean"
+            },
+            "spike_ins_fasta": {
+                "term": {
+                    "$ref": "_terms.yaml#/spike_ins_fasta"
+                },
+                "type": "string"
+            },
+            "spike_ins_concentration": {
+                "term": {
+                    "$ref": "_terms.yaml#/spike_ins_concentration"
+                },
+                "type": "string"
+            },
+            "library_selection": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_selection"
+                },
+                "description": "Library selection method.",
+                "enum": [
+                    "Hybrid_Selection",
+                    "PCR",
+                    "Affinity_Enrichment",
+                    "Poly-T_Enrichment",
+                    "RNA_Depletion",
+                    "Other",
+                    "miRNA Size Fractionation",
+                    "rRNA Depletion",
+                    "Random"
+                ]
+            },
+            "library_preparation_kit_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_preparation_kit_name"
+                },
+                "description": "Name of library preparation kit.",
+                "type": "string"
+            },
+            "library_preparation_kit_vendor": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_preparation_kit_vendor"
+                },
+                "description": "Vendor of library preparation kit.",
+                "type": "string"
+            },
+            "library_preparation_kit_catalog_number": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_preparation_kit_catalog_number"
+                },
+                "description": "Catalog of library preparation kit.",
+                "type": "string"
+            },
+            "library_preparation_kit_version": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_preparation_kit_version"
+                },
+                "description": "Version of library preparation kit.",
+                "type": "string"
+            },
+            "library_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_name"
+                },
+                "description": "Name of the library.",
+                "type": "string"
+            },
+            "target_capture_kit_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/target_capture_kit_name"
+                },
+                "type": "string"
+            },
+            "target_capture_kit_vendor": {
+                "term": {
+                    "$ref": "_terms.yaml#/target_capture_kit_vendor"
+                },
+                "type": "string"
+            },
+            "target_capture_kit_catalog_number": {
+                "term": {
+                    "$ref": "_terms.yaml#/target_capture_kit_catalog_number"
+                },
+                "type": "string"
+            },
+            "target_capture_kit_version": {
+                "term": {
+                    "$ref": "_terms.yaml#/target_capture_kit_version"
+                },
+                "type": "string"
+            },
+            "target_capture_kit_target_region": {
+                "term": {
+                    "$ref": "_terms.yaml#/target_capture_kit_target_region"
+                },
+                "type": "string"
+            },
+            "size_selection_range": {
+                "term": {
+                    "$ref": "_terms.yaml#/size_selection_range"
+                },
+                "type": "string"
+            },
+            "adapter_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/adapter_name"
+                },
+                "description": "Name of the sequencing adapter.",
+                "type": "string"
+            },
+            "adapter_sequence": {
+                "term": {
+                    "$ref": "_terms.yaml#/adapter_sequence"
+                },
+                "description": "Base sequence of the sequencing adapter.",
+                "type": "string"
+            },
+            "to_trim_adapter_sequence": {
+                "term": {
+                    "$ref": "_terms.yaml#/to_trim_adapter_sequence"
+                },
+                "type": "boolean"
+            },
+            "library_strand": {
+                "term": {
+                    "$ref": "_terms.yaml#/library_strand"
+                },
+                "description": "Library stranded-ness.",
+                "enum": [
+                    "Unstranded",
+                    "First_Stranded",
+                    "Second_Stranded",
+                    "Not Applicable"
+                ]
+            },
+            "base_caller_name": {
+                "term": {
+                    "$ref": "_terms.yaml#/base_caller_name"
+                },
+                "description": "Name of the base caller.",
+                "type": "string"
+            },
+            "base_caller_version": {
+                "term": {
+                    "$ref": "_terms.yaml#/base_caller_version"
+                },
+                "description": "Version of the base caller.",
+                "type": "string"
+            },
+            "is_paired_end": {
+                "term": {
+                    "$ref": "_terms.yaml#/is_paired_end"
+                },
+                "description": "Are the reads paired end?",
+                "type": "boolean"
+            },
+            "read_length": {
+                "type": "integer",
+                "description": "The length of the reads."
+            },
+            "read_group_name": {
+                "description": "Read group name.",
+                "type": "string"
+            },
+            "barcoding_applied": {
+                "description": "True/False: was barcoding applied?",
+                "type": "boolean"
+            },
+            "chipseq_antibody": {
+                "description": "NEW: The antibody used in the ChIP-Seq assay.",
+                "enum": [
+                    "abcam ab4729 anti-H3K27ac",
+                    "Unknown",
+                    "Not Applicable"
+                ]
+            },
+            "chipseq_target": {
+                "description": "NEW: The antibody used in the ChIP-Seq assay.",
+                "enum": [
+                    "H3K4me1",
+                    "H3K4me3",
+                    "H3K9me3",
+                    "H3K27me3",
+                    "H3K36me3",
+                    "H3K27ac",
+                    "Input Control",
+                    "Unknown"
+                ]
+            },
+            "days_to_sequencing": {
+                "description": "NEW: Number of days between the date used for index and the date the read group was sequenced.",
+                "type": "integer",
+                "minimum": -32872
+            },
+            "fragment_maximum_length": {
+                "description": "NEW: Maximum length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
+                "type": "integer",
+                "minimum": 0
+            },
+            "fragment_mean_length": {
+                "description": "NEW: Mean length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
+                "type": "number",
+                "minimum": 0
+            },
+            "fragment_minimum_length": {
+                "description": "NEW: Minimum length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
+                "type": "integer",
+                "minimum": 0
+            },
+            "fragment_standard_deviation_length": {
+                "description": "NEW: Standard deviation of the sequenced fragments length (e.g., as predicted by Agilent Bioanalyzer).",
+                "type": "number",
+                "minimum": 0
+            },
+            "fragmentation_enzyme": {
+                "description": "NEW: The restriction enzyme used for nucleotide fragmentation.",
+                "enum": [
+                    "MboI",
+                    "Unknown",
+                    "Not Applicable"
+                ]
+            },
+            "lane_number": {
+                "description": "NEW: The basic machine unit for sequencing. For Illumina machines, this reflects the physical lane number. Wrong or missing information may affect analysis results.",
+                "type": "integer",
+                "minimum": 1
+            },
+            "multiplex_barcode": {
+                "description": "NEW: The barcode/index sequence used. Wrong or missing information may affect analysis results.",
+                "type": "string",
+                "pattern": "^[0-9ACGTURYSWKMBDHVN]+([\\+\\-][0-9ACGTURYSWKMBDHVN]+){,2}$"
+            },
+            "number_expect_cells": {
+                "description": "NEW: Expected number of recovered cells in droplet-based single-cell libraries.",
+                "type": "integer",
+                "minimum": 0
+            },
+            "single_cell_library": {
+                "description": "NEW: Library preparation strategy that distinguishes different single-cell assays.",
+                "enum": [
+                    "Chromium 3' Gene Expression v2 Library",
+                    "Chromium 3' Gene Expression v3 Library",
+                    "Chromium scATAC v1 Library",
+                    "Smart-Seq2"
+                ]
+            },
+            "target_capture_kit": {
+                "description": "NEW: Description that can uniquely identify a target capture kit. Suggested value is a combination of vendor, kit name, and kit version.",
+                "enum": [
+                    "Custom AmpliSeq Cancer Hotspot GENIE-MDA Augmented Panel v1 - 46 Genes",
+                    "Custom GENIE-DFCI OncoPanel - 275 Genes",
+                    "Custom GENIE-DFCI Oncopanel - 300 Genes",
+                    "Custom GENIE-DFCI Oncopanel - 447 Genes",
+                    "Custom HaloPlex DLBCL Panel - 370 Genes",
+                    "Custom Ion AmpliSeq Hotspot GENIE-MOSC3 Augmented Panel - 74 Genes",
+                    "Custom Large Construct Capture TARGET-OS Panel - 8 Genes",
+                    "Custom MSK IMPACT Panel - 341 Genes",
+                    "Custom MSK IMPACT Panel - 410 Genes",
+                    "Custom MSK IMPACT Panel - 468 Genes",
+                    "Custom Myeloid GENIE-VICC Panel - 37 Genes",
+                    "Custom Personalis ACEcp VAREPOP-APOLLO Panel v2",
+                    "Custom PGDX SureSelect CancerSelect VAREPOP-APOLLO Panel - 203 Genes",
+                    "Custom PGDX SureSelect CancerSelect VAREPOP-APOLLO Panel - 88 Genes",
+                    "Custom SeqCap EZ BeatAML Panel - 12.5 Mb",
+                    "Custom SeqCap EZ HGSC VCRome v2.1 ER Augmented v1",
+                    "Custom SeqCap EZ HGSC VCRome v2.1 ER Augmented v2",
+                    "Custom SeqCap EZ TARGET-OS Panel - 7.0 Mb",
+                    "Custom Solid Tumor GENIE-VICC Panel - 34 Genes",
+                    "Custom SureSelect CGCI-BLGSP Panel - 4.6 Mb",
+                    "Custom SureSelect CGCI-HTMCP-CC KMT2D And Hotspot Panel - 37.0 Kb",
+                    "Custom SureSelect CGCI-HTMCP-CC Panel - 19.7 Mb",
+                    "Custom SureSelect GENIE-UHN Panel - 555 Genes",
+                    "Custom SureSelect Human All Exon v1.1 Plus 3 Boosters",
+                    "Custom SureSelect TARGET-AML_NBL_WT Panel - 2.8 Mb",
+                    "Custom Twist Broad Exome v1.0 - 35.0 Mb",
+                    "Custom Twist Broad PanCancer Panel - 396 Genes",
+                    "Custom Twist MP2PRT-WT Panel - 52 Kb",
+                    "Foundation Medicine T5a Panel - 322 Genes",
+                    "Foundation Medicine T7 Panel - 429 Genes",
+                    "Ion AmpliSeq Cancer Hotspot Panel v2",
+                    "Ion AmpliSeq Comprehensive Cancer Panel",
+                    "Nextera DNA Exome",
+                    "Nextera Rapid Capture Exome v1.2",
+                    "Not Applicable",
+                    "SeqCap EZ HGSC VCRome v2.1",
+                    "SeqCap EZ Human Exome v2.0",
+                    "SeqCap EZ Human Exome v3.0",
+                    "SureSelect Human All Exon v3",
+                    "SureSelect Human All Exon v4",
+                    "SureSelect Human All Exon v5",
+                    "SureSelect Human All Exon v5 + UTR",
+                    "TruSeq Amplicon Cancer Panel",
+                    "TruSeq Exome Enrichment - 62 Mb",
+                    "TruSeq RNA Exome",
+                    "TruSight Myeloid Sequencing Panel",
+                    "Twist Human Comprehensive Exome",
+                    "xGen Exome Research Panel v1.0",
+                    "Unknown"
+                ]
+            },
+            "aliquots": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "submitted_copy_number.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "additionalProperties": false,
+        "category": "data_file",
+        "description": "Data file containing normalized copy number information from an aliquot.\n",
+        "id": "submitted_copy_number",
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "backref": "submitted_copy_number_files",
+                        "label": "data_from",
+                        "multiplicity": "many_to_many",
+                        "name": "core_metadata_collections",
+                        "required": false,
+                        "target_type": "core_metadata_collection"
+                    },
+                    {
+                        "exclusive": true,
+                        "required": false,
+                        "subgroup": [
+                            {
+                                "backref": "submitted_copy_number_files",
+                                "label": "derived_from",
+                                "multiplicity": "one_to_one",
+                                "name": "aliquots",
+                                "required": false,
+                                "target_type": "aliquot"
+                            },
+                            {
+                                "backref": "submitted_copy_number_files",
+                                "label": "derived_from",
+                                "multiplicity": "many_to_many",
+                                "name": "read_groups",
+                                "required": false,
+                                "target_type": "read_group"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "namespace": "http://gdc.nci.nih.gov",
+        "program": "*",
+        "project": "*",
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "aliquots": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "type": "string"
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": "string"
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "type": "string"
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "type": "string"
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "type": {
+                "enum": [
+                    "submitted_copy_number"
+                ]
+            }
+        },
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "data_format",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "experimental_strategy"
+        ],
+        "submittable": true,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "title": "Submitted Copy Number",
+        "type": "object",
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "validators": null
+    },
+    "experiment.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "experiment",
+        "title": "Experiment",
+        "type": "object",
+        "namespace": "http://bloodprofilingatlas.org/bpa/",
+        "category": "administrative",
+        "program": "*",
+        "project": "*",
+        "description": "A coordinated set of actions and observations designed to generate data, with the ultimate goal of discovery or hypothesis testing.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "name": "projects",
+                "backref": "experiments",
+                "label": "performed_for",
+                "target_type": "project",
+                "multiplicity": "many_to_one",
+                "required": true
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "projects"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "enum": [
+                    "experiment"
+                ]
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "number_experimental_group": {
+                "description": "The number denoting this experiment's place within the group within the whole.",
+                "type": [
+                    "integer"
+                ]
+            },
+            "number_samples_per_experimental_group": {
+                "description": "The number of samples contained within this experimental group.",
+                "type": [
+                    "integer"
+                ]
+            },
+            "experimental_description": {
+                "description": "A brief description of the experiment being performed.",
+                "type": [
+                    "string"
+                ]
+            },
+            "experimental_intent": {
+                "description": "Summary of the goals the experiment is designed to discover.",
+                "type": [
+                    "string"
+                ]
+            },
+            "associated_experiment": {
+                "description": "The submitter_id for any experiment with which this experiment is associated, paired, or matched.",
+                "type": [
+                    "string"
+                ]
+            },
+            "type_of_sample": {
+                "description": "String indicator identifying the types of samples as contrived or clinical.",
+                "type": [
+                    "string"
+                ]
+            },
+            "type_of_specimen": {
+                "description": "Broad description of the specimens used in the experiment.",
+                "type": [
+                    "string"
+                ]
+            },
+            "marker_panel_description": {
+                "description": "Brief description of the marker panel used in this experiment.",
+                "type": "string"
+            },
+            "somatic_mutations_identified": {
+                "description": "Are somatic mutations identified for this experiment?",
+                "type": "boolean"
+            },
+            "indels_identified": {
+                "description": "Are indels identified in this experiment?",
+                "type": "boolean"
+            },
+            "copy_numbers_identified": {
+                "description": "Are copy number variations identified in this experiment?",
+                "type": "boolean"
+            },
+            "type_of_data": {
+                "description": "Is the data raw or processed?",
+                "enum": [
+                    "Raw",
+                    "Processed"
+                ]
+            },
+            "data_description": {
+                "description": "Brief description of the data being provided for this experiment.",
+                "type": "string"
+            },
+            "projects": {
+                "$ref": "_definitions.yaml#/to_one_project"
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "aliquot.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "aliquot",
+        "title": "Aliquot",
+        "type": "object",
+        "category": "biospecimen",
+        "program": "*",
+        "project": "*",
+        "description": "Pertaining to a portion of the whole; any one of two or more samples of something, of the same volume or weight.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "links": [
+            {
+                "name": "follow_ups",
+                "backref": "aliquots",
+                "label": "describes",
+                "target_type": "follow_up",
+                "multiplicity": "many_to_one",
+                "required": true
+            },
+            {
+                "name": "labs",
+                "backref": "aliquots",
+                "label": "describe",
+                "target_type": "lab",
+                "multiplicity": "many_to_one",
+                "required": false
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "follow_ups"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "description": "The legacy barcode used before prior to the use UUIDs. For TCGA this is bcraliquotbarcode."
+            },
+            "aliquot_amount": {
+                "description": "Aliquot quantity, (weight in grams or volume in ml and other units).",
+                "type": [
+                    "number"
+                ]
+            },
+            "aliquot_collection_unit": {
+                "description": "Unit of the aliquot sample ( example: grams, ml, etc).",
+                "enum": [
+                    "gram",
+                    "ml",
+                    "Collection Kit"
+                ]
+            },
+            "specimen_type": {
+                "description": "Term to describe type of sample collection.",
+                "enum": [
+                    "Platelet Poor Plasma",
+                    "HCl Acidified Plasma",
+                    "HCl Sodium Citrate Plasma",
+                    "CPT Plasma",
+                    "PBMC",
+                    "Serum",
+                    "DNA",
+                    "Lysed RBC",
+                    "Platelet Rich Plasma",
+                    "Urine",
+                    "Stool",
+                    "Anakinra",
+                    "NEAT Plasma",
+                    "Saliva",
+                    "Whole Blood (DNA)",
+                    "Unknown Code",
+                    "Liver Tissue"
+                ]
+            },
+            "container_type": {
+                "description": "Term to describe type of container in which Aliquot was collected.",
+                "enum": [
+                    "2 ml microtubes",
+                    "1.5 ml Fisherbrand Sterile Microcentrifuge Tubes with Screw Caps",
+                    "1.8 ml cryovials",
+                    "5 ml cryovials",
+                    "15 ml cryovials",
+                    "Collection Cups",
+                    "Collection Kit"
+                ]
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "follow_ups": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "submitted_somatic_mutation.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "submitted_somatic_mutation",
+        "title": "Submitted Somatic Mutation",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "data_file",
+        "program": "*",
+        "project": "*",
+        "description": "Data file containing somatic mutation calls from a read group.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_somatic_mutations",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "read_groups",
+                        "backref": "submitted_somatic_mutations",
+                        "label": "derived_from",
+                        "target_type": "read_group",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "data_format",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "experimental_strategy"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "submitted_somatic_mutation"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "type": "string"
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "type": "string"
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": "string"
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "type": "string"
+            },
+            "total_variants": {
+                "description": "The total number of variants detected carrying a base change difference from the reference genome.",
+                "type": "integer"
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "experimental_metadata.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "experimental_metadata",
+        "title": "Experimental Metadata",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "metadata_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing the metadata for the experiment performed, or processed quantification data (e.g. proteomics) produced by a lab.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "experiment_metadata_files",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "experiments",
+                        "backref": "experiment_metadata_files",
+                        "label": "derived_from",
+                        "target_type": "experiment",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "labs",
+                        "backref": "experiment_metadata_files",
+                        "label": "produced_by",
+                        "target_type": "lab",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "experimental_metadata"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Experimental Metadata",
+                    "Proteomics Quantification"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "description": "The experimental strategy used to generate the data file.",
+                "enum": [
+                    "LC-MS/MS",
+                    "TMT",
+                    "Label-Free",
+                    "DIA",
+                    "DDA",
+                    "SWATH"
+                ]
+            },
+            "measurement_type": {
+                "description": "The type of quantification measurement in the data file.",
+                "enum": [
+                    "pep",
+                    "Quantity",
+                    "Spectral_Count",
+                    "iBAQ"
+                ]
+            },
+            "instrument_model": {
+                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "software_version": {
+                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "experiments": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "sample.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "sample",
+        "title": "Sample",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "biospecimen",
+        "program": "*",
+        "project": "*",
+        "description": "Any material sample taken from a biological entity for testing, diagnostic, propagation, treatment or research purposes, including a sample obtained from a living organism or taken from the biological object after halting of all its life functions. Biospecimen can contain one or more components including but not limited to cellular molecules, cells, tissues, organs, body fluids, embryos, and body excretory products.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "follow_ups"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "links": [
+            {
+                "name": "follow_ups",
+                "backref": "samples",
+                "label": "derived_from",
+                "target_type": "follow_up",
+                "multiplicity": "many_to_one",
+                "required": true
+            },
+            {
+                "name": "diagnoses",
+                "backref": "samples",
+                "label": "related_to",
+                "target_type": "diagnosis",
+                "multiplicity": "many_to_one",
+                "required": false
+            }
+        ],
+        "properties": {
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "description": "The legacy barcode used before prior to the use UUIDs, varies by project. For TCGA this is bcrsamplebarcode.\n"
+            },
+            "sample_collection": {
+                "description": "Text term to describe if any sample collection was done during the visit",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "visit_date": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "sample_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/sample_type"
+                },
+                "enum": [
+                    "Blood Derived Normal",
+                    "Blood Derived Normal - Serum",
+                    "Blood Derived Normal - Whole blood",
+                    "Blood Derived Normal - Platelet Poor Plasma",
+                    "Blood Derived Normal - HCl/Neat Plasma",
+                    "Peripheral Blood Mononuclear Cells",
+                    "Urine",
+                    "Saliva",
+                    "Stool",
+                    "Anakinra"
+                ]
+            },
+            "sample_date_time": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "days_to_collection": {
+                "description": "The number of days from the index date to the date a sample was collected for a specific study or project",
+                "type": "integer"
+            },
+            "sample_fast": {
+                "description": "Text term to describe if the patient fasted before sample collection",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "sample_fast_hours": {
+                "description": "Number representing the total hours fasted before collecting the sample",
+                "type": "integer"
+            },
+            "sample_number_of_tubes": {
+                "description": "Number representing the number of tubes collected",
+                "type": "integer"
+            },
+            "total_cell_count": {
+                "description": "Number representing the total cell count in the sample (in million)",
+                "type": "integer"
+            },
+            "sample_home_collection_kit": {
+                "description": "Text term to describe if the sample was collected using a home collection kit",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "preservation_method": {
+                "description": "Text term that represents the method used to preserve the sample",
+                "enum": [
+                    "Frozen",
+                    "Unknown",
+                    "Not Reported"
+                ]
+            },
+            "time_between_collection_and_freezing": {
+                "description": "Numeric representation of the elapsed time between the sample collection and freezing, measured in minutes",
+                "type": "integer"
+            },
+            "sample_transportation_method_ice": {
+                "description": "Text term that describes if the sample was transported to study site on ice",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "days_to_receive_sample": {
+                "description": "The number of days from the index date to the date a sample was received by the site",
+                "type": "integer"
+            },
+            "sample_exception": {
+                "description": "Text term represents exceptions during sample collection",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "sample_exception_clotted": {
+                "description": "Text term that represents if the sample exception was applied due to clotting",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_contaminated": {
+                "description": "Text term that represents if the sample exception was applied due to contamination",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_damaged": {
+                "description": "Text term that represents if the sample exception was applied due to damage",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_hemolyzed": {
+                "desciption": "Text term that represents if the sample exception was applied due to hemolysis",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_hemorrhagic": {
+                "description": "Text term that represents if the sample exception was applied due to hemorrhage",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_late_processing_8H": {
+                "description": "Text term that represents if the sample exception was applied due to late processing by 8 hours",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_late_processing_24H": {
+                "description": "Text term that represents if the sample exception was applied due to late processing by 24 hours",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_lipemic": {
+                "description": "Text term that represents if the sample exception was applied due to lipemia",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_necrotic": {
+                "description": "Text term that represents if the sample exception was applied due to necrosis",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_insufficient_quantity": {
+                "description": "Text term that represents if the sample exception was applied due to insufficient quantity",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "sample_exception_thawed": {
+                "description": "Text term that represents if the sample exception was applied due to thawing",
+                "enum": [
+                    "Yes",
+                    "No",
+                    "N/A"
+                ]
+            },
+            "follow_ups": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "diagnoses": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "project_id": {
+                "type": "string"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "core_metadata_collection.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "core_metadata_collection",
+        "title": "Core Metadata Collection",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "administrative",
+        "program": "*",
+        "project": "*",
+        "description": "Structured description of a collection of several dataset\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "links": [
+            {
+                "name": "projects",
+                "backref": "core_metadata_collections",
+                "label": "data_from",
+                "target_type": "project",
+                "multiplicity": "many_to_one",
+                "required": true
+            }
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "projects"
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/ubiquitous_properties",
+            "contributor": {
+                "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.\n",
+                "type": "string"
+            },
+            "coverage": {
+                "description": "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN] (http://www.getty.edu/research/tools/vocabulary/tgn/index.html). Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges.\n",
+                "type": "string"
+            },
+            "creator": {
+                "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.\n",
+                "type": "string"
+            },
+            "date": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "description": {
+                "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.\n",
+                "type": "string"
+            },
+            "format": {
+                "description": "The file format, physical medium, or dimensions of the resource. Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME] (http://www.iana.org/assignments/media-types/). \n",
+                "type": "string"
+            },
+            "language": {
+                "description": "A language of the resource. Recommended best practice is to use a controlled vocabulary such as RFC 4646 (http://www.ietf.org/rfc/rfc4646.txt).\n",
+                "type": "string"
+            },
+            "publisher": {
+                "description": "An entity responsible for making the resource available. Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity.\n",
+                "type": "string"
+            },
+            "relation": {
+                "description": "A related resource. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.\ufffd\n",
+                "type": "string"
+            },
+            "rights": {
+                "description": "Information about rights held in and over the resource. Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights.\n",
+                "type": "string"
+            },
+            "source": {
+                "description": "A related resource from which the described resource is derived. The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.\n",
+                "type": "string"
+            },
+            "subject": {
+                "description": "The topic of the resource. Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary.\n",
+                "type": "string"
+            },
+            "title": {
+                "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.\n",
+                "type": "string"
+            },
+            "data_type": {
+                "description": "The nature or genre of the resource. Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.\n",
+                "type": "string"
+            },
+            "projects": {
+                "$ref": "_definitions.yaml#/to_one_project"
             }
         }
     },
@@ -770,16 +3076,16 @@
             }
         }
     },
-    "publication.yaml": {
+    "demographic.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "publication",
-        "title": "Publication",
+        "id": "demographic",
+        "title": "Demographic",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
-        "category": "administrative",
+        "category": "clinical",
         "program": "*",
         "project": "*",
-        "description": "Publication for a project.",
+        "description": "Data for the characterization of the patient by means of segementing the population (e.g., characterization by age, sex, or race).\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -792,108 +3098,21 @@
         ],
         "links": [
             {
-                "name": "projects",
-                "backref": "publications",
-                "label": "refers_to",
-                "target_type": "project",
-                "multiplicity": "many_to_many",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "publication"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "pmid": {
-                "type": "string"
-            },
-            "doi": {
-                "type": "string"
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_many_project"
-            },
-            "project_id": {
-                "type": "string"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "aliquot.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "aliquot",
-        "title": "Aliquot",
-        "type": "object",
-        "category": "biospecimen",
-        "program": "*",
-        "project": "*",
-        "description": "Pertaining to a portion of the whole; any one of two or more samples of something, of the same volume or weight.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "links": [
-            {
-                "name": "follow_ups",
-                "backref": "aliquots",
+                "name": "cases",
+                "backref": "demographics",
                 "label": "describes",
-                "target_type": "follow_up",
-                "multiplicity": "many_to_one",
+                "target_type": "case",
+                "multiplicity": "one_to_one",
                 "required": true
-            },
-            {
-                "name": "labs",
-                "backref": "aliquots",
-                "label": "describe",
-                "target_type": "lab",
-                "multiplicity": "many_to_one",
-                "required": false
             }
         ],
         "required": [
             "submitter_id",
             "type",
-            "follow_ups"
+            "cases"
+        ],
+        "preferred": [
+            "year_of_death"
         ],
         "uniqueKeys": [
             [
@@ -919,399 +3138,155 @@
                 "type": [
                     "string",
                     "null"
-                ],
-                "description": "The legacy barcode used before prior to the use UUIDs. For TCGA this is bcraliquotbarcode."
+                ]
             },
-            "aliquot_amount": {
-                "description": "Aliquot quantity, (weight in grams or volume in ml and other units).",
+            "ethnicity": {
+                "description": "An individual's self-described social and cultural grouping, specifically whether an individual describes themselves as Hispanic or Latino. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+                "enum": [
+                    "hispanic or latino",
+                    "not hispanic or latino",
+                    "Unknown",
+                    "not reported",
+                    "not allowed to collect",
+                    "None"
+                ]
+            },
+            "sex": {
+                "description": "Sex of patient at birth.",
+                "enum": [
+                    "male",
+                    "female",
+                    "unknown",
+                    "unspecified"
+                ]
+            },
+            "gender": {
+                "description": "Text designations that identify gender. Gender is described as the assemblage of properties that distinguish people on the basis of their societal roles. [Explanatory Comment 1: Identification of gender is based upon self-report and may come from a form, questionnaire, interview, etc.]",
+                "enum": [
+                    "female",
+                    "male",
+                    "unknown",
+                    "unspecified",
+                    "not reported",
+                    "None"
+                ]
+            },
+            "race": {
+                "description": "An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
+                "enum": [
+                    "white",
+                    "american indian or alaska native",
+                    "black or african american",
+                    "asian",
+                    "native hawaiian or other pacific islander",
+                    "other",
+                    "Unknown",
+                    "More than one race",
+                    "not reported",
+                    "not allowed to contact",
+                    "None"
+                ]
+            },
+            "education": {
+                "description": "Text term to identify the highest level of education complete for the patient.",
+                "type": [
+                    "string"
+                ]
+            },
+            "marital": {
+                "description": "What is your current marital status?",
+                "enum": [
+                    "Divorced",
+                    "Domestic Partnership",
+                    "Married",
+                    "Never Married",
+                    "Separated",
+                    "Widowed",
+                    "Missing",
+                    "Living with significant other (common law marriage)",
+                    "Single, never married"
+                ]
+            },
+            "cur_employ_stat": {
+                "description": "The indicator to ask if the patient is currently employed.",
+                "enum": [
+                    "No",
+                    "Not sure",
+                    "Missing",
+                    "Yes"
+                ]
+            },
+            "vital_status": {
+                "description": "The survival state of the person registered on the protocol.",
+                "enum": [
+                    "Alive",
+                    "Dead",
+                    "Unknown",
+                    "Not Reported",
+                    "None"
+                ]
+            },
+            "age_at_index": {
+                "description": "The patient's age (in years) on the reference or anchor date date used during date obfuscation.",
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "year_of_birth": {
+                "description": "Numeric value to represent the calendar year in which an individual was born.",
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "days_to_death": {
+                "description": "Number of days between the date used for index and the date from a person's date of death represented as a calculated number of days.",
                 "type": [
                     "number"
                 ]
             },
-            "aliquot_collection_unit": {
-                "description": "Unit of the aliquot sample ( example: grams, ml, etc).",
-                "enum": [
-                    "gram",
-                    "ml",
-                    "Collection Kit"
+            "year_of_death": {
+                "description": "Numeric value to represent the year of the death of an individual.",
+                "type": [
+                    "number"
                 ]
             },
-            "specimen_type": {
-                "description": "Term to describe type of sample collection.",
-                "enum": [
-                    "Platelet Poor Plasma",
-                    "HCl Acidified Plasma",
-                    "HCl Sodium Citrate Plasma",
-                    "CPT Plasma",
-                    "PBMC",
-                    "Serum",
-                    "DNA",
-                    "Lysed RBC",
-                    "Platelet Rich Plasma",
-                    "Urine",
-                    "Stool",
-                    "Anakinra",
-                    "NEAT Plasma",
-                    "Saliva",
-                    "Whole Blood (DNA)",
-                    "Unknown Code",
-                    "Liver Tissue"
+            "cause_of_death_primary": {
+                "description": "Text term to identify the primary cause of death for a patient.",
+                "type": [
+                    "string"
                 ]
             },
-            "container_type": {
-                "description": "Term to describe type of container in which Aliquot was collected.",
-                "enum": [
-                    "2 ml microtubes",
-                    "1.5 ml Fisherbrand Sterile Microcentrifuge Tubes with Screw Caps",
-                    "1.8 ml cryovials",
-                    "5 ml cryovials",
-                    "15 ml cryovials",
-                    "Collection Cups",
-                    "Collection Kit"
+            "cause_of_death_secondary": {
+                "description": "Text term to identify the secondary cause of death for a patient.",
+                "type": [
+                    "string"
                 ]
+            },
+            "death_related_to": {
+                "description": "Text term to identify common conditions to which the death is related.",
+                "enum": [
+                    "Spontaneous Bacterial Peritonitis",
+                    "Sepsis",
+                    "Esophageal Variceal Bleed",
+                    "Gastric Variceal Bleeding",
+                    "Liver Disease - Other",
+                    "Unknown",
+                    "Other"
+                ]
+            },
+            "cases": {
+                "$ref": "_definitions.yaml#/to_one"
             },
             "project_id": {
                 "$ref": "_definitions.yaml#/project_id"
-            },
-            "labs": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "follow_ups": {
-                "$ref": "_definitions.yaml#/to_one"
             },
             "created_datetime": {
                 "$ref": "_definitions.yaml#/datetime"
             },
             "updated_datetime": {
                 "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "project.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "project",
-        "title": "Project",
-        "type": "object",
-        "program": "*",
-        "project": "*",
-        "category": "administrative",
-        "description": "Any specifically defined piece of work that is undertaken or attempted to meet a single requirement. (NCIt C47885)\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "state",
-            "released",
-            "releasable",
-            "intended_release_date"
-        ],
-        "required": [
-            "code",
-            "name",
-            "dbgap_accession_number",
-            "programs"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "code"
-            ]
-        ],
-        "links": [
-            {
-                "name": "programs",
-                "backref": "projects",
-                "label": "member_of",
-                "target_type": "program",
-                "multiplicity": "many_to_one",
-                "required": true
-            }
-        ],
-        "constraints": null,
-        "properties": {
-            "type": {
-                "type": "string"
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id",
-                "description": "UUID for the project."
-            },
-            "name": {
-                "type": "string",
-                "description": "Display name/brief description for the project."
-            },
-            "code": {
-                "type": "string",
-                "description": "Unique identifier for the project."
-            },
-            "investigator_name": {
-                "description": "Name of the principal investigator for the project.",
-                "type": "string"
-            },
-            "investigator_affiliation": {
-                "description": "The investigator's affiliation with respect to a research institution.",
-                "type": "string"
-            },
-            "date_collected": {
-                "description": "The date or date range in which the project data was collected.",
-                "type": "string"
-            },
-            "availability_type": {
-                "description": "Is the project open or restricted?",
-                "enum": [
-                    "Open",
-                    "Restricted"
-                ]
-            },
-            "availability_mechanism": {
-                "description": "Mechanism by which the project will be made avilable.",
-                "type": "string"
-            },
-            "support_source": {
-                "description": "The name of source providing support/grant resources.",
-                "type": "string"
-            },
-            "support_id": {
-                "description": "The ID of the source providing support/grant resources.",
-                "type": "string"
-            },
-            "programs": {
-                "$ref": "_definitions.yaml#/to_one",
-                "description": "Indicates that the project is logically part of the indicated project.\n"
-            },
-            "state": {
-                "description": "The possible states a project can be in.  All but `open` are\nequivalent to some type of locked state.\n",
-                "default": "open",
-                "enum": [
-                    "open",
-                    "review",
-                    "submitted",
-                    "processing",
-                    "closed",
-                    "legacy"
-                ]
-            },
-            "released": {
-                "description": "To release a project is to tell the GDC to include all submitted\nentities in the next GDC index.\n",
-                "default": false,
-                "type": "boolean"
-            },
-            "releasable": {
-                "description": "A project can only be released by the user when `releasable` is true.\n",
-                "default": false,
-                "type": "boolean"
-            },
-            "intended_release_date": {
-                "description": "Tracks a Project's intended release date.",
-                "type": "string",
-                "format": "date-time"
-            },
-            "dbgap_accession_number": {
-                "type": "string",
-                "description": "The dbgap accession number provided for the project."
-            }
-        }
-    },
-    "experimental_metadata.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "experimental_metadata",
-        "title": "Experimental Metadata",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "metadata_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing the metadata for the experiment performed, or processed quantification data (e.g. proteomics) produced by a lab.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "experiment_metadata_files",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "experiments",
-                        "backref": "experiment_metadata_files",
-                        "label": "derived_from",
-                        "target_type": "experiment",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "labs",
-                        "backref": "experiment_metadata_files",
-                        "label": "produced_by",
-                        "target_type": "lab",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "experimental_metadata"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "type": [
-                    "string"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Experimental Metadata",
-                    "Proteomics Quantification"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "type": [
-                    "string"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "description": "The experimental strategy used to generate the data file.",
-                "enum": [
-                    "LC-MS/MS",
-                    "TMT",
-                    "Label-Free",
-                    "DIA",
-                    "DDA",
-                    "SWATH"
-                ]
-            },
-            "measurement_type": {
-                "description": "The type of quantification measurement in the data file.",
-                "enum": [
-                    "pep",
-                    "Quantity",
-                    "Spectral_Count",
-                    "iBAQ"
-                ]
-            },
-            "instrument_model": {
-                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "software_version": {
-                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "experiments": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "labs": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "program.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "program",
-        "title": "Program",
-        "type": "object",
-        "category": "administrative",
-        "program": "*",
-        "project": "*",
-        "description": "A broad framework of goals to be achieved. (NCIt C52647)\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id"
-        ],
-        "required": [
-            "name",
-            "dbgap_accession_number"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "name"
-            ]
-        ],
-        "links": [],
-        "properties": {
-            "type": {
-                "type": "string"
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "name": {
-                "type": "string",
-                "description": "Full name/title of the program."
-            },
-            "dbgap_accession_number": {
-                "type": "string",
-                "description": "The dbgap accession number provided for the program."
             }
         }
     },
@@ -1686,396 +3661,6 @@
             },
             "updated_datetime": {
                 "$ref": "#/datetime"
-            }
-        }
-    },
-    "slide_image.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "slide_image",
-        "title": "Slide Image",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "data_file",
-        "program": "*",
-        "project": "*",
-        "description": "Data file containing image of a slide.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "slides",
-                        "backref": "slide_images",
-                        "label": "data_from",
-                        "target_type": "slide",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "slide_images",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "slide_image"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Biospecimen",
-                    "Slide Image",
-                    "Mass Cytometry"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "image",
-                    "Single Cell Image",
-                    "Raw IMC Data",
-                    "Single Channel IMC Image",
-                    "Antibody Panel Added"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "type": "string"
-            },
-            "experimental_strategy": {
-                "description": "Classification of the slide type with respect to its experimental use.",
-                "enum": [
-                    "Diagnostic Slide",
-                    "Tissue Slide"
-                ]
-            },
-            "cell_type": {
-                "description": "The type of cell being imaged or otherwised analysed.",
-                "type": "string"
-            },
-            "cell_identifier": {
-                "description": "An alternative identifier for a given cell type.",
-                "type": "string"
-            },
-            "cell_count": {
-                "description": "Count of the cell type being imaged or otherwise analysed.",
-                "type": "integer"
-            },
-            "frame_identifier": {
-                "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
-                "type": "string"
-            },
-            "panel_used": {
-                "description": "Name or other identifier given to the panel used during an IMC run.",
-                "type": "string"
-            },
-            "protocol_used": {
-                "description": "Name or other identifier given to the protocol used during an IMC run.",
-                "type": "string"
-            },
-            "run_name": {
-                "description": "Name, number, or other identifier given to the run that generated this slide image.",
-                "type": "string"
-            },
-            "slides": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "core_metadata_collection.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "core_metadata_collection",
-        "title": "Core Metadata Collection",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "administrative",
-        "program": "*",
-        "project": "*",
-        "description": "Structured description of a collection of several dataset\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "links": [
-            {
-                "name": "projects",
-                "backref": "core_metadata_collections",
-                "label": "data_from",
-                "target_type": "project",
-                "multiplicity": "many_to_one",
-                "required": true
-            }
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects"
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/ubiquitous_properties",
-            "contributor": {
-                "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.\n",
-                "type": "string"
-            },
-            "coverage": {
-                "description": "The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended best practice is to use a controlled vocabulary such as the Thesaurus of Geographic Names [TGN] (http://www.getty.edu/research/tools/vocabulary/tgn/index.html). Where appropriate, named places or time periods can be used in preference to numeric identifiers such as sets of coordinates or date ranges.\n",
-                "type": "string"
-            },
-            "creator": {
-                "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.\n",
-                "type": "string"
-            },
-            "date": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "description": {
-                "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.\n",
-                "type": "string"
-            },
-            "format": {
-                "description": "The file format, physical medium, or dimensions of the resource. Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME] (http://www.iana.org/assignments/media-types/). \n",
-                "type": "string"
-            },
-            "language": {
-                "description": "A language of the resource. Recommended best practice is to use a controlled vocabulary such as RFC 4646 (http://www.ietf.org/rfc/rfc4646.txt).\n",
-                "type": "string"
-            },
-            "publisher": {
-                "description": "An entity responsible for making the resource available. Examples of a Publisher include a person, an organization, or a service. Typically, the name of a Publisher should be used to indicate the entity.\n",
-                "type": "string"
-            },
-            "relation": {
-                "description": "A related resource. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.\ufffd\n",
-                "type": "string"
-            },
-            "rights": {
-                "description": "Information about rights held in and over the resource. Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights.\n",
-                "type": "string"
-            },
-            "source": {
-                "description": "A related resource from which the described resource is derived. The described resource may be derived from the related resource in whole or in part. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system.\n",
-                "type": "string"
-            },
-            "subject": {
-                "description": "The topic of the resource. Typically, the subject will be represented using keywords, key phrases, or classification codes. Recommended best practice is to use a controlled vocabulary.\n",
-                "type": "string"
-            },
-            "title": {
-                "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.\n",
-                "type": "string"
-            },
-            "data_type": {
-                "description": "The nature or genre of the resource. Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.\n",
-                "type": "string"
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_one_project"
-            }
-        }
-    },
-    "submitted_unaligned_reads.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_unaligned_reads",
-        "title": "Submitted Unaligned Reads",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "data_file",
-        "program": "*",
-        "project": "*",
-        "description": "Data file containing unaligned reads that have not been GDC Harmonized.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "read_groups",
-                        "backref": "submitted_unaligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "read_group",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_unaligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format",
-            "experimental_strategy"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "submitted_unaligned_reads"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Sequencing Data",
-                    "Sequencing Reads",
-                    "Raw Sequencing Data"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Unaligned Reads"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "BAM",
-                    "FASTQ"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "description": "UPDATED: The sequencing strategy used to generate the data file.",
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "Low Pass WGS",
-                    "Validation",
-                    "RNA-Seq",
-                    "miRNA-Seq",
-                    "Total RNA-Seq",
-                    "DNA Panel",
-                    "ATAC-Seq",
-                    "Bisulfite-Seq",
-                    "ChIP-Seq",
-                    "HiChIP",
-                    "m6A MeRIP-Seq",
-                    "scATAC-Seq",
-                    "scRNA-Seq",
-                    "Targeted Sequencing"
-                ]
-            },
-            "read_pair_number": {
-                "description": "NEW: Denotes whether a submitted FASTQ file contains forward (R1) or reverse (R2) reads for paired-end sequencing.",
-                "enum": [
-                    "R1",
-                    "R2",
-                    "R3",
-                    "Not Applicable"
-                ]
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
             }
         }
     },
@@ -3755,282 +5340,16 @@
             }
         }
     },
-    "experiment.yaml": {
+    "submitted_aligned_reads.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "experiment",
-        "title": "Experiment",
-        "type": "object",
-        "namespace": "http://bloodprofilingatlas.org/bpa/",
-        "category": "administrative",
-        "program": "*",
-        "project": "*",
-        "description": "A coordinated set of actions and observations designed to generate data, with the ultimate goal of discovery or hypothesis testing.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "name": "projects",
-                "backref": "experiments",
-                "label": "performed_for",
-                "target_type": "project",
-                "multiplicity": "many_to_one",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "experiment"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "number_experimental_group": {
-                "description": "The number denoting this experiment's place within the group within the whole.",
-                "type": [
-                    "integer"
-                ]
-            },
-            "number_samples_per_experimental_group": {
-                "description": "The number of samples contained within this experimental group.",
-                "type": [
-                    "integer"
-                ]
-            },
-            "experimental_description": {
-                "description": "A brief description of the experiment being performed.",
-                "type": [
-                    "string"
-                ]
-            },
-            "experimental_intent": {
-                "description": "Summary of the goals the experiment is designed to discover.",
-                "type": [
-                    "string"
-                ]
-            },
-            "associated_experiment": {
-                "description": "The submitter_id for any experiment with which this experiment is associated, paired, or matched.",
-                "type": [
-                    "string"
-                ]
-            },
-            "type_of_sample": {
-                "description": "String indicator identifying the types of samples as contrived or clinical.",
-                "type": [
-                    "string"
-                ]
-            },
-            "type_of_specimen": {
-                "description": "Broad description of the specimens used in the experiment.",
-                "type": [
-                    "string"
-                ]
-            },
-            "marker_panel_description": {
-                "description": "Brief description of the marker panel used in this experiment.",
-                "type": "string"
-            },
-            "somatic_mutations_identified": {
-                "description": "Are somatic mutations identified for this experiment?",
-                "type": "boolean"
-            },
-            "indels_identified": {
-                "description": "Are indels identified in this experiment?",
-                "type": "boolean"
-            },
-            "copy_numbers_identified": {
-                "description": "Are copy number variations identified in this experiment?",
-                "type": "boolean"
-            },
-            "type_of_data": {
-                "description": "Is the data raw or processed?",
-                "enum": [
-                    "Raw",
-                    "Processed"
-                ]
-            },
-            "data_description": {
-                "description": "Brief description of the data being provided for this experiment.",
-                "type": "string"
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_one_project"
-            },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "submitted_methylation.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_methylation",
-        "title": "Submitted Methylation",
-        "type": "object",
-        "namespace": "https://www.bloodpac.org/",
-        "category": "data_file",
-        "program": "*",
-        "project": "*",
-        "description": "DNA methylation data files contain information on raw and normalized signal intensities, detection confidence and calculated beta values for methylated and unmethylated probes. DNA methylation is an epigenetic mark which can be associated with transcriptional inactivity when located in promoter regions.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_methylation_files",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "aliquots",
-                        "backref": "submitted_methylation_files",
-                        "label": "data_from",
-                        "target_type": "aliquot",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "submitted_methylation"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Methylation Data"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Methylation Intensity Values"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "IDAT"
-                ]
-            },
-            "assay_method": {
-                "enum": [
-                    "Methylation Array"
-                ]
-            },
-            "assay_instrument": {
-                "enum": [
-                    "Illumina"
-                ]
-            },
-            "assay_instrument_model": {
-                "enum": [
-                    "Illumina Infinium HumanMethylation450",
-                    "Illumina Infinium HumanMethylation450K"
-                ]
-            },
-            "aliquots": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "submitted_somatic_mutation.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_somatic_mutation",
-        "title": "Submitted Somatic Mutation",
+        "id": "submitted_aligned_reads",
+        "title": "Submitted Aligned Reads",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
         "category": "data_file",
         "program": "*",
         "project": "*",
-        "description": "Data file containing somatic mutation calls from a read group.\n",
+        "description": "Data file containing aligned reads that are used as input to GDC workflows.\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -4049,18 +5368,18 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_somatic_mutations",
+                        "name": "read_groups",
+                        "backref": "submitted_aligned_reads_files",
                         "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_many",
+                        "target_type": "read_group",
+                        "multiplicity": "one_to_many",
                         "required": false
                     },
                     {
-                        "name": "read_groups",
-                        "backref": "submitted_somatic_mutations",
-                        "label": "derived_from",
-                        "target_type": "read_group",
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_aligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
                         "multiplicity": "many_to_many",
                         "required": false
                     }
@@ -4091,36 +5410,66 @@
             "$ref": "_definitions.yaml#/data_file_properties",
             "type": {
                 "enum": [
-                    "submitted_somatic_mutation"
+                    "submitted_aligned_reads"
                 ]
             },
             "data_category": {
                 "term": {
                     "$ref": "_terms.yaml#/data_category"
                 },
-                "type": "string"
+                "enum": [
+                    "Sequencing Data",
+                    "Sequencing Reads",
+                    "Raw Sequencing Data"
+                ]
             },
             "data_type": {
                 "term": {
                     "$ref": "_terms.yaml#/data_type"
                 },
-                "type": "string"
+                "enum": [
+                    "Aligned Reads",
+                    "Alignment Coordinates"
+                ]
             },
             "data_format": {
                 "term": {
                     "$ref": "_terms.yaml#/data_format"
                 },
-                "type": "string"
+                "enum": [
+                    "BAM",
+                    "BED",
+                    "CRAM"
+                ]
             },
             "experimental_strategy": {
                 "term": {
                     "$ref": "_terms.yaml#/experimental_strategy"
                 },
-                "type": "string"
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "Low Pass WGS",
+                    "Validation",
+                    "RNA-Seq",
+                    "miRNA-Seq",
+                    "Total RNA-Seq",
+                    "DNA Panel",
+                    "ATAC-Seq",
+                    "Bisulfite-Seq",
+                    "ChIP-Seq",
+                    "HiChIP",
+                    "m6A MeRIP-Seq",
+                    "scATAC-Seq",
+                    "scRNA-Seq",
+                    "Targeted Sequencing"
+                ]
             },
-            "total_variants": {
-                "description": "The total number of variants detected carrying a base change difference from the reference genome.",
-                "type": "integer"
+            "proc_internal": {
+                "description": "NEW: Internal data processing flag.",
+                "enum": [
+                    "dna-seq skip"
+                ]
             },
             "read_groups": {
                 "$ref": "_definitions.yaml#/to_many"
@@ -5089,555 +6438,6 @@
             }
         }
     },
-    "slide_count.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "slide_count",
-        "title": "Slide Count",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "notation",
-        "program": "*",
-        "project": "*",
-        "description": "Information pertaining to processed results obtained from slides; often in the form of counts.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "name": "slides",
-                "backref": "slide_counts",
-                "label": "data_from",
-                "target_type": "slide",
-                "multiplicity": "many_to_many",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "slides"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "slide_count"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "cell_type": {
-                "description": "The type of cell being counted or measured.",
-                "type": "string"
-            },
-            "cell_identifier": {
-                "description": "An alternative identifier for a given cell type.",
-                "type": "string"
-            },
-            "cell_count": {
-                "description": "Raw count of a particular cell type.",
-                "type": "integer"
-            },
-            "ck_signal": {
-                "description": "Numeric quantification of the CK signal.",
-                "type": "number"
-            },
-            "biomarker_signal": {
-                "description": "Numeric quantification of the biomarker signal.",
-                "type": "number"
-            },
-            "er_localization": {
-                "description": "Cellular localization of the endoplasmic reticulum as determined by staining.",
-                "enum": [
-                    "Nuclear",
-                    "Cytoplasmic",
-                    "Both",
-                    "None",
-                    "Not Determined"
-                ]
-            },
-            "frame_identifier": {
-                "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
-                "type": "string"
-            },
-            "relative_nuclear_size": {
-                "description": "The ratio of the single cell's nucleus size to the average of the surrounding cells.",
-                "type": "number"
-            },
-            "relative_nuclear_intensity": {
-                "description": "The ratio of the single cell's nuclear staining intensity to the average of the surrounding cells.",
-                "type": "number"
-            },
-            "relative_cytokeratin_intensity": {
-                "description": "The ratio of the single cell's cytokeratin staining intensity to the average of the surrounding cells.",
-                "type": "number"
-            },
-            "relative_er_intensity": {
-                "description": "The ratio of the single cell's endoplasmic reticulum staining intensity to the average of the surrounding cells.",
-                "type": "number"
-            },
-            "run_name": {
-                "description": "The name or identifier given to the run that was used to generate this slide count.",
-                "type": "string"
-            },
-            "slides": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "project_id": {
-                "type": "string"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "exposure.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "exposure",
-        "title": "Exposure",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "clinical",
-        "program": "*",
-        "project": "*",
-        "description": "Clinically relevant patient information not immediately resulting from genetic predispositions.\n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "required": [
-            "submitter_id",
-            "type"
-        ],
-        "links": [
-            {
-                "name": "cases",
-                "backref": "exposures",
-                "label": "describes",
-                "target_type": "case",
-                "multiplicity": "many_to_one",
-                "required": true
-            }
-        ],
-        "preferred": [
-            "cigarettes_per_day",
-            "years_smoked"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "exposure"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "alcohol_history": {
-                "term": {
-                    "$ref": "_terms.yaml#/alcohol_history"
-                },
-                "type": "string"
-            },
-            "alcohol_intensity": {
-                "term": {
-                    "$ref": "_terms.yaml#/alcohol_intensity"
-                },
-                "type": "string"
-            },
-            "bmi": {
-                "term": {
-                    "$ref": "_terms.yaml#/bmi"
-                },
-                "type": "number"
-            },
-            "cigarettes_per_day": {
-                "term": {
-                    "$ref": "_terms.yaml#/cigarettes_per_day"
-                },
-                "type": "number"
-            },
-            "height": {
-                "term": {
-                    "$ref": "_terms.yaml#/height"
-                },
-                "type": "number"
-            },
-            "pack_years_smoked": {
-                "term": {
-                    "$ref": "_terms.yaml#/pack_years_smoked"
-                },
-                "type": "number"
-            },
-            "tobacco_smoking_onset_year": {
-                "term": {
-                    "$ref": "_terms.yaml#/tobacco_smoking_onset_year"
-                },
-                "type": "integer"
-            },
-            "tobacco_smoking_quit_year": {
-                "term": {
-                    "$ref": "_terms.yaml#/tobacco_smoking_quit_year"
-                },
-                "type": "integer"
-            },
-            "tobacco_smoking_status": {
-                "term": {
-                    "$ref": "_terms.yaml#/tobacco_smoking_status"
-                },
-                "enum": [
-                    "1",
-                    "2",
-                    "3",
-                    "4",
-                    "5",
-                    "6",
-                    "7",
-                    "Unknown",
-                    "Not Reported",
-                    "Not Allowed To Collect"
-                ]
-            },
-            "weight": {
-                "term": {
-                    "$ref": "_terms.yaml#/weight"
-                },
-                "type": "number"
-            },
-            "years_smoked": {
-                "term": {
-                    "$ref": "_terms.yaml#/years_smoked"
-                },
-                "type": "number"
-            },
-            "cases": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "read_group_qc.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "read_group_qc",
-        "title": "Read Group QC",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "notation",
-        "project": "*",
-        "program": "*",
-        "description": "GDC QC run metadata.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "read_group_qcs",
-                        "label": "data_from",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_unaligned_reads_files",
-                        "backref": "read_group_qcs",
-                        "label": "data_from",
-                        "target_type": "submitted_unaligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
-            },
-            {
-                "name": "read_groups",
-                "label": "generated_from",
-                "target_type": "read_group",
-                "multiplicity": "many_to_one",
-                "required": true,
-                "backref": "read_group_qcs"
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "workflow_link",
-            "type",
-            "percent_gc_content",
-            "encoding",
-            "total_sequences",
-            "basic_statistics",
-            "per_base_sequence_quality",
-            "per_tile_sequence_quality",
-            "per_sequence_quality_score",
-            "per_base_sequence_content",
-            "per_sequence_gc_content",
-            "per_base_n_content",
-            "sequence_length_distribution",
-            "sequence_duplication_levels",
-            "overrepresented_sequences",
-            "adapter_content",
-            "kmer_content",
-            "read_groups"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "type": {
-                "enum": [
-                    "read_group_qc"
-                ]
-            },
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "Read Group Quality Control"
-                ]
-            },
-            "fastq_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/file_name"
-                },
-                "type": "string"
-            },
-            "percent_aligned": {
-                "description": "The percent of reads with at least one reported alignment.",
-                "type": "integer",
-                "minimum": 0,
-                "maximum": 100
-            },
-            "percent_gc_content": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_gc_content"
-                },
-                "type": "integer",
-                "minimum": 0,
-                "maximum": 100
-            },
-            "encoding": {
-                "term": {
-                    "$ref": "_terms.yaml#/encoding"
-                },
-                "type": "string"
-            },
-            "total_aligned_reads": {
-                "description": "The total number of reads with at least one reported alignment.",
-                "type": "integer"
-            },
-            "total_sequences": {
-                "term": {
-                    "$ref": "_terms.yaml#/total_sequences"
-                },
-                "type": "integer"
-            },
-            "basic_statistics": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_base_sequence_quality": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_tile_sequence_quality": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_sequence_quality_score": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_base_sequence_content": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_sequence_gc_content": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "per_base_n_content": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "sequence_length_distribution": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "sequence_duplication_levels": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "overrepresented_sequences": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "adapter_content": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "kmer_content": {
-                "$ref": "_definitions.yaml#/qc_metrics_state"
-            },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "submitted_unaligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "keyword.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "keyword",
-        "title": "Keyword",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "administrative",
-        "program": "*",
-        "project": "*",
-        "description": "A keyword for a project.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "links": [
-            {
-                "name": "projects",
-                "backref": "keywords",
-                "label": "describe",
-                "target_type": "project",
-                "multiplicity": "many_to_many",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "enum": [
-                    "keyword"
-                ]
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "keyword_name": {
-                "description": "The name of the keyword.",
-                "type": "string"
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_many_project"
-            },
-            "project_id": {
-                "type": "string"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
     "family_history.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "id": "family_history",
@@ -5755,16 +6555,21 @@
             }
         }
     },
-    "slide.yaml": {
+    "_settings.yaml": {
+        "enable_case_cache": false,
+        "_dict_commit": "d077a402c97d392a6954e032591cc50c94a91523",
+        "_dict_version": "2.3.0"
+    },
+    "keyword.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "slide",
-        "title": "Slide",
+        "id": "keyword",
+        "title": "Keyword",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
-        "category": "biospecimen",
+        "category": "administrative",
         "program": "*",
         "project": "*",
-        "description": "A digital image, microscopic or otherwise, of any sample, portion, or sub-part thereof. (GDC)\n",
+        "description": "A keyword for a project.",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -5777,10 +6582,10 @@
         ],
         "links": [
             {
-                "name": "samples",
-                "backref": "slides",
-                "label": "derived_from",
-                "target_type": "sample",
+                "name": "projects",
+                "backref": "keywords",
+                "label": "describe",
+                "target_type": "project",
                 "multiplicity": "many_to_many",
                 "required": true
             }
@@ -5788,7 +6593,7 @@
         "required": [
             "submitter_id",
             "type",
-            "samples"
+            "projects"
         ],
         "uniqueKeys": [
             [
@@ -5801,7 +6606,9 @@
         ],
         "properties": {
             "type": {
-                "type": "string"
+                "enum": [
+                    "keyword"
+                ]
             },
             "id": {
                 "$ref": "_definitions.yaml#/UUID",
@@ -5816,124 +6623,96 @@
                     "null"
                 ]
             },
-            "apoptotic_concentration": {
-                "description": "The concentration, in cells/mL, of apoptotic cells in the slide blood.",
-                "type": "number"
-            },
-            "ctc_concentration": {
-                "description": "The concentration, in cells/mL, of traditional CTC cells (intact and enlarged cell and nucleus, cytokeratin positive, and CD45 negative) in the slide blood.",
-                "type": "number"
-            },
-            "ctc_low_concentration": {
-                "description": "The concentration, in cells/mL, of CTC-low cells (those with low cytokeratin levels compared to traditional CTCs) in the slide blood.",
-                "type": "number"
-            },
-            "ctc_small_concentration": {
-                "description": "The concentration, in cells/mL, of CTC-small cells (those with a small nuclear and cellular size relative to traditional CTCs) in the slide blood.",
-                "type": "number"
-            },
-            "section_location": {
-                "term": {
-                    "$ref": "_terms.yaml#/section_location"
-                },
+            "keyword_name": {
+                "description": "The name of the keyword.",
                 "type": "string"
             },
-            "methanol_added": {
-                "description": "True/False indicator for if methanol was used in the slide preparation process.",
-                "type": "boolean"
-            },
-            "number_proliferating_cells": {
-                "term": {
-                    "$ref": "_terms.yaml#/number_proliferating_cells"
-                },
-                "type": "integer"
-            },
-            "number_nucleated_cells": {
-                "description": "The total number of nucleated cells identified on the slide.",
-                "type": "integer"
-            },
-            "percent_tumor_cells": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_tumor_cells"
-                },
-                "type": "number"
-            },
-            "percent_tumor_nuclei": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_tumor_nuclei"
-                },
-                "type": "number"
-            },
-            "percent_normal_cells": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_normal_cells"
-                },
-                "type": "number"
-            },
-            "percent_necrosis": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_necrosis"
-                },
-                "type": "number"
-            },
-            "percent_stromal_cells": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_stromal_cells"
-                },
-                "type": "number"
-            },
-            "percent_inflam_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_inflam_infiltration"
-                },
-                "type": "number"
-            },
-            "percent_lymphocyte_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_lymphocyte_infiltration"
-                },
-                "type": "number"
-            },
-            "percent_monocyte_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_monocyte_infiltration"
-                },
-                "type": "number"
-            },
-            "percent_granulocyte_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_granulocyte_infiltration"
-                },
-                "type": "number"
-            },
-            "percent_neutrophil_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_neutrophil_infiltration"
-                },
-                "type": "number"
-            },
-            "percent_eosinophil_infiltration": {
-                "term": {
-                    "$ref": "_terms.yaml#/percent_eosinophil_infiltration"
-                },
-                "type": "number"
-            },
-            "run_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "run_name": {
-                "description": "Name, number, or other identifier given to this slide's run.",
-                "type": "string"
-            },
-            "slide_identifier": {
-                "description": "Unique identifier given to the this slide.",
-                "type": "string"
-            },
-            "samples": {
-                "$ref": "_definitions.yaml#/to_many"
+            "projects": {
+                "$ref": "_definitions.yaml#/to_many_project"
             },
             "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
+                "type": "string"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            }
+        }
+    },
+    "acknowledgement.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "acknowledgement",
+        "title": "Acknowledgement",
+        "type": "object",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "administrative",
+        "program": "*",
+        "project": "*",
+        "description": "Acknowledgement of an individual involved in a project.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "state",
+            "created_datetime",
+            "updated_datetime"
+        ],
+        "links": [
+            {
+                "name": "projects",
+                "backref": "acknowledgements",
+                "label": "contribute_to",
+                "target_type": "project",
+                "multiplicity": "many_to_many",
+                "required": true
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "projects"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "type": {
+                "enum": [
+                    "acknowledgement"
+                ]
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "acknowledgee": {
+                "description": "The indvidiual or group being acknowledged by the project.",
+                "type": "string"
+            },
+            "projects": {
+                "$ref": "_definitions.yaml#/to_many_project"
+            },
+            "project_id": {
+                "type": "string"
             },
             "created_datetime": {
                 "$ref": "_definitions.yaml#/datetime"
@@ -6175,16 +6954,16 @@
             }
         }
     },
-    "sample.yaml": {
+    "exposure.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "sample",
-        "title": "Sample",
+        "id": "exposure",
+        "title": "Exposure",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
-        "category": "biospecimen",
+        "category": "clinical",
         "program": "*",
         "project": "*",
-        "description": "Any material sample taken from a biological entity for testing, diagnostic, propagation, treatment or research purposes, including a sample obtained from a living organism or taken from the biological object after halting of all its life functions. Biospecimen can contain one or more components including but not limited to cellular molecules, cells, tissues, organs, body fluids, embryos, and body excretory products.\n",
+        "description": "Clinically relevant patient information not immediately resulting from genetic predispositions.\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -6197,8 +6976,21 @@
         ],
         "required": [
             "submitter_id",
-            "type",
-            "follow_ups"
+            "type"
+        ],
+        "links": [
+            {
+                "name": "cases",
+                "backref": "exposures",
+                "label": "describes",
+                "target_type": "case",
+                "multiplicity": "many_to_one",
+                "required": true
+            }
+        ],
+        "preferred": [
+            "cigarettes_per_day",
+            "years_smoked"
         ],
         "uniqueKeys": [
             [
@@ -6209,27 +7001,11 @@
                 "submitter_id"
             ]
         ],
-        "links": [
-            {
-                "name": "follow_ups",
-                "backref": "samples",
-                "label": "derived_from",
-                "target_type": "follow_up",
-                "multiplicity": "many_to_one",
-                "required": true
-            },
-            {
-                "name": "diagnoses",
-                "backref": "samples",
-                "label": "related_to",
-                "target_type": "diagnosis",
-                "multiplicity": "many_to_one",
-                "required": false
-            }
-        ],
         "properties": {
             "type": {
-                "type": "string"
+                "enum": [
+                    "exposure"
+                ]
             },
             "id": {
                 "$ref": "_definitions.yaml#/UUID",
@@ -6242,195 +7018,90 @@
                 "type": [
                     "string",
                     "null"
-                ],
-                "description": "The legacy barcode used before prior to the use UUIDs, varies by project. For TCGA this is bcrsamplebarcode.\n"
-            },
-            "sample_collection": {
-                "description": "Text term to describe if any sample collection was done during the visit",
-                "enum": [
-                    "Yes",
-                    "No"
                 ]
             },
-            "visit_date": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "sample_type": {
+            "alcohol_history": {
                 "term": {
-                    "$ref": "_terms.yaml#/sample_type"
+                    "$ref": "_terms.yaml#/alcohol_history"
+                },
+                "type": "string"
+            },
+            "alcohol_intensity": {
+                "term": {
+                    "$ref": "_terms.yaml#/alcohol_intensity"
+                },
+                "type": "string"
+            },
+            "bmi": {
+                "term": {
+                    "$ref": "_terms.yaml#/bmi"
+                },
+                "type": "number"
+            },
+            "cigarettes_per_day": {
+                "term": {
+                    "$ref": "_terms.yaml#/cigarettes_per_day"
+                },
+                "type": "number"
+            },
+            "height": {
+                "term": {
+                    "$ref": "_terms.yaml#/height"
+                },
+                "type": "number"
+            },
+            "pack_years_smoked": {
+                "term": {
+                    "$ref": "_terms.yaml#/pack_years_smoked"
+                },
+                "type": "number"
+            },
+            "tobacco_smoking_onset_year": {
+                "term": {
+                    "$ref": "_terms.yaml#/tobacco_smoking_onset_year"
+                },
+                "type": "integer"
+            },
+            "tobacco_smoking_quit_year": {
+                "term": {
+                    "$ref": "_terms.yaml#/tobacco_smoking_quit_year"
+                },
+                "type": "integer"
+            },
+            "tobacco_smoking_status": {
+                "term": {
+                    "$ref": "_terms.yaml#/tobacco_smoking_status"
                 },
                 "enum": [
-                    "Blood Derived Normal",
-                    "Blood Derived Normal - Serum",
-                    "Blood Derived Normal - Whole blood",
-                    "Blood Derived Normal - Platelet Poor Plasma",
-                    "Blood Derived Normal - HCl/Neat Plasma",
-                    "Peripheral Blood Mononuclear Cells",
-                    "Urine",
-                    "Saliva",
-                    "Stool",
-                    "Anakinra"
-                ]
-            },
-            "sample_date_time": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "days_to_collection": {
-                "description": "The number of days from the index date to the date a sample was collected for a specific study or project",
-                "type": "integer"
-            },
-            "sample_fast": {
-                "description": "Text term to describe if the patient fasted before sample collection",
-                "enum": [
-                    "Yes",
-                    "No"
-                ]
-            },
-            "sample_fast_hours": {
-                "description": "Number representing the total hours fasted before collecting the sample",
-                "type": "integer"
-            },
-            "sample_number_of_tubes": {
-                "description": "Number representing the number of tubes collected",
-                "type": "integer"
-            },
-            "total_cell_count": {
-                "description": "Number representing the total cell count in the sample (in million)",
-                "type": "integer"
-            },
-            "sample_home_collection_kit": {
-                "description": "Text term to describe if the sample was collected using a home collection kit",
-                "enum": [
-                    "Yes",
-                    "No"
-                ]
-            },
-            "preservation_method": {
-                "description": "Text term that represents the method used to preserve the sample",
-                "enum": [
-                    "Frozen",
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "7",
                     "Unknown",
-                    "Not Reported"
+                    "Not Reported",
+                    "Not Allowed To Collect"
                 ]
             },
-            "time_between_collection_and_freezing": {
-                "description": "Numeric representation of the elapsed time between the sample collection and freezing, measured in minutes",
-                "type": "integer"
+            "weight": {
+                "term": {
+                    "$ref": "_terms.yaml#/weight"
+                },
+                "type": "number"
             },
-            "sample_transportation_method_ice": {
-                "description": "Text term that describes if the sample was transported to study site on ice",
-                "enum": [
-                    "Yes",
-                    "No"
-                ]
+            "years_smoked": {
+                "term": {
+                    "$ref": "_terms.yaml#/years_smoked"
+                },
+                "type": "number"
             },
-            "days_to_receive_sample": {
-                "description": "The number of days from the index date to the date a sample was received by the site",
-                "type": "integer"
-            },
-            "sample_exception": {
-                "description": "Text term represents exceptions during sample collection",
-                "enum": [
-                    "Yes",
-                    "No"
-                ]
-            },
-            "sample_exception_clotted": {
-                "description": "Text term that represents if the sample exception was applied due to clotting",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_contaminated": {
-                "description": "Text term that represents if the sample exception was applied due to contamination",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_damaged": {
-                "description": "Text term that represents if the sample exception was applied due to damage",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_hemolyzed": {
-                "desciption": "Text term that represents if the sample exception was applied due to hemolysis",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_hemorrhagic": {
-                "description": "Text term that represents if the sample exception was applied due to hemorrhage",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_late_processing_8H": {
-                "description": "Text term that represents if the sample exception was applied due to late processing by 8 hours",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_late_processing_24H": {
-                "description": "Text term that represents if the sample exception was applied due to late processing by 24 hours",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_lipemic": {
-                "description": "Text term that represents if the sample exception was applied due to lipemia",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_necrotic": {
-                "description": "Text term that represents if the sample exception was applied due to necrosis",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_insufficient_quantity": {
-                "description": "Text term that represents if the sample exception was applied due to insufficient quantity",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "sample_exception_thawed": {
-                "description": "Text term that represents if the sample exception was applied due to thawing",
-                "enum": [
-                    "Yes",
-                    "No",
-                    "N/A"
-                ]
-            },
-            "follow_ups": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "diagnoses": {
+            "cases": {
                 "$ref": "_definitions.yaml#/to_one"
             },
             "project_id": {
-                "type": "string"
+                "$ref": "_definitions.yaml#/project_id"
             },
             "created_datetime": {
                 "$ref": "_definitions.yaml#/datetime"
@@ -6440,492 +7111,145 @@
             }
         }
     },
-    "read_group.yaml": {
+    "project.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "read_group",
-        "title": "Read Group",
+        "id": "project",
+        "title": "Project",
         "type": "object",
-        "description": "Sequencing reads from one lane of an NGS experiment.",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "biospecimen",
-        "project": "*",
         "program": "*",
+        "project": "*",
+        "category": "administrative",
+        "description": "Any specifically defined piece of work that is undertaken or attempted to meet a single requirement. (NCIt C47885)\n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
         "systemProperties": [
             "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "name": "aliquots",
-                "label": "derived_from",
-                "target_type": "aliquot",
-                "multiplicity": "many_to_one",
-                "required": true,
-                "backref": "read_groups"
-            }
+            "state",
+            "released",
+            "releasable",
+            "intended_release_date"
         ],
         "required": [
-            "type",
-            "submitter_id",
-            "aliquots"
+            "code",
+            "name",
+            "dbgap_accession_number",
+            "programs"
         ],
         "uniqueKeys": [
             [
                 "id"
             ],
             [
-                "project_id",
-                "submitter_id"
+                "code"
             ]
         ],
+        "links": [
+            {
+                "name": "programs",
+                "backref": "projects",
+                "label": "member_of",
+                "target_type": "program",
+                "multiplicity": "many_to_one",
+                "required": true
+            }
+        ],
+        "constraints": null,
         "properties": {
-            "id": {
-                "$ref": "_definitions.yaml#/UUID"
-            },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "submitter_id": {
+            "type": {
                 "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id",
+                "description": "UUID for the project."
+            },
+            "name": {
+                "type": "string",
+                "description": "Display name/brief description for the project."
+            },
+            "code": {
+                "type": "string",
+                "description": "Unique identifier for the project."
+            },
+            "investigator_name": {
+                "description": "Name of the principal investigator for the project.",
+                "type": "string"
+            },
+            "investigator_affiliation": {
+                "description": "The investigator's affiliation with respect to a research institution.",
+                "type": "string"
+            },
+            "date_collected": {
+                "description": "The date or date range in which the project data was collected.",
+                "type": "string"
+            },
+            "availability_type": {
+                "description": "Is the project open or restricted?",
+                "enum": [
+                    "Open",
+                    "Restricted"
+                ]
+            },
+            "availability_mechanism": {
+                "description": "Mechanism by which the project will be made avilable.",
+                "type": "string"
+            },
+            "support_source": {
+                "description": "The name of source providing support/grant resources.",
+                "type": "string"
+            },
+            "support_id": {
+                "description": "The ID of the source providing support/grant resources.",
+                "type": "string"
+            },
+            "programs": {
+                "$ref": "_definitions.yaml#/to_one",
+                "description": "Indicates that the project is logically part of the indicated project.\n"
             },
             "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "type": {
+                "description": "The possible states a project can be in.  All but `open` are\nequivalent to some type of locked state.\n",
+                "default": "open",
                 "enum": [
-                    "read_group"
+                    "open",
+                    "review",
+                    "submitted",
+                    "processing",
+                    "closed",
+                    "legacy"
                 ]
             },
-            "experiment_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/experiment_name"
-                },
-                "description": "Submitter-defined name for the experiment.",
-                "type": "string"
-            },
-            "sequencing_center": {
-                "term": {
-                    "$ref": "_terms.yaml#/sequencing_center"
-                },
-                "type": "string"
-            },
-            "sequencing_date": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "platform": {
-                "term": {
-                    "$ref": "_terms.yaml#/platform"
-                },
-                "description": "Name of the platform used to obtain data.",
-                "enum": [
-                    "Illumina",
-                    "SOLiD",
-                    "LS454",
-                    "Ion Torrent",
-                    "Complete Genomics",
-                    "PacBio",
-                    "Other"
-                ]
-            },
-            "instrument_model": {
-                "terms": {
-                    "$ref": "_terms.yaml#/instrument_model"
-                },
-                "description": "Specific model of sequencing instrument used.",
-                "enum": [
-                    "454 GS FLX Titanium",
-                    "AB SOLiD 4",
-                    "AB SOLiD 2",
-                    "AB SOLiD 3",
-                    "Complete Genomics",
-                    "Illumina HiSeq X Ten",
-                    "Illumina HiSeq X Five",
-                    "Illumina Genome Analyzer II",
-                    "Illumina Genome Analyzer IIx",
-                    "Illumina HiSeq 2000",
-                    "Illumina HiSeq 2500",
-                    "Illumina HiSeq 4000",
-                    "Illumina NovaSeq 6000",
-                    "Illumina MiSeq",
-                    "Illumina NextSeq",
-                    "Ion Torrent PGM",
-                    "Ion Torrent Proton",
-                    "Ion Torrent S5",
-                    "PacBio RS",
-                    "Ion S5 XL System, Ion 530 Chip",
-                    "Other",
-                    "Unknown",
-                    "Not Reported"
-                ]
-            },
-            "library_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_strategy"
-                },
-                "description": "Library strategy.",
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "RNA-Seq",
-                    "ChIP-Seq",
-                    "miRNA-Seq",
-                    "Bisulfite-Seq",
-                    "Validation",
-                    "Amplicon",
-                    "Other",
-                    "ATAC-Seq",
-                    "m6A MeRIP-Seq",
-                    "scATAC-Seq",
-                    "scRNA-Seq",
-                    "Targeted Sequencing",
-                    "DNA-Seq"
-                ]
-            },
-            "RIN": {
-                "term": {
-                    "$ref": "_terms.yaml#/RIN"
-                },
-                "description": "A numerical assessment of the integrity of RNA based on the entire electrophoretic trace of the RNA sample including the presence or absence of degradation products.",
-                "type": "number"
-            },
-            "flow_cell_barcode": {
-                "term": {
-                    "$ref": "_terms.yaml#/flow_cell_barcode"
-                },
-                "description": "Flow cell barcode. Wrong or missing information may affect analysis results.",
-                "type": "string"
-            },
-            "includes_spike_ins": {
-                "term": {
-                    "$ref": "_terms.yaml#/includes_spike_ins"
-                },
-                "description": "Spike-in",
+            "released": {
+                "description": "To release a project is to tell the GDC to include all submitted\nentities in the next GDC index.\n",
+                "default": false,
                 "type": "boolean"
             },
-            "spike_ins_fasta": {
-                "term": {
-                    "$ref": "_terms.yaml#/spike_ins_fasta"
-                },
-                "type": "string"
-            },
-            "spike_ins_concentration": {
-                "term": {
-                    "$ref": "_terms.yaml#/spike_ins_concentration"
-                },
-                "type": "string"
-            },
-            "library_selection": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_selection"
-                },
-                "description": "Library selection method.",
-                "enum": [
-                    "Hybrid_Selection",
-                    "PCR",
-                    "Affinity_Enrichment",
-                    "Poly-T_Enrichment",
-                    "RNA_Depletion",
-                    "Other",
-                    "miRNA Size Fractionation",
-                    "rRNA Depletion",
-                    "Random"
-                ]
-            },
-            "library_preparation_kit_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_preparation_kit_name"
-                },
-                "description": "Name of library preparation kit.",
-                "type": "string"
-            },
-            "library_preparation_kit_vendor": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_preparation_kit_vendor"
-                },
-                "description": "Vendor of library preparation kit.",
-                "type": "string"
-            },
-            "library_preparation_kit_catalog_number": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_preparation_kit_catalog_number"
-                },
-                "description": "Catalog of library preparation kit.",
-                "type": "string"
-            },
-            "library_preparation_kit_version": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_preparation_kit_version"
-                },
-                "description": "Version of library preparation kit.",
-                "type": "string"
-            },
-            "library_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_name"
-                },
-                "description": "Name of the library.",
-                "type": "string"
-            },
-            "target_capture_kit_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/target_capture_kit_name"
-                },
-                "type": "string"
-            },
-            "target_capture_kit_vendor": {
-                "term": {
-                    "$ref": "_terms.yaml#/target_capture_kit_vendor"
-                },
-                "type": "string"
-            },
-            "target_capture_kit_catalog_number": {
-                "term": {
-                    "$ref": "_terms.yaml#/target_capture_kit_catalog_number"
-                },
-                "type": "string"
-            },
-            "target_capture_kit_version": {
-                "term": {
-                    "$ref": "_terms.yaml#/target_capture_kit_version"
-                },
-                "type": "string"
-            },
-            "target_capture_kit_target_region": {
-                "term": {
-                    "$ref": "_terms.yaml#/target_capture_kit_target_region"
-                },
-                "type": "string"
-            },
-            "size_selection_range": {
-                "term": {
-                    "$ref": "_terms.yaml#/size_selection_range"
-                },
-                "type": "string"
-            },
-            "adapter_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/adapter_name"
-                },
-                "description": "Name of the sequencing adapter.",
-                "type": "string"
-            },
-            "adapter_sequence": {
-                "term": {
-                    "$ref": "_terms.yaml#/adapter_sequence"
-                },
-                "description": "Base sequence of the sequencing adapter.",
-                "type": "string"
-            },
-            "to_trim_adapter_sequence": {
-                "term": {
-                    "$ref": "_terms.yaml#/to_trim_adapter_sequence"
-                },
+            "releasable": {
+                "description": "A project can only be released by the user when `releasable` is true.\n",
+                "default": false,
                 "type": "boolean"
             },
-            "library_strand": {
-                "term": {
-                    "$ref": "_terms.yaml#/library_strand"
-                },
-                "description": "Library stranded-ness.",
-                "enum": [
-                    "Unstranded",
-                    "First_Stranded",
-                    "Second_Stranded",
-                    "Not Applicable"
-                ]
-            },
-            "base_caller_name": {
-                "term": {
-                    "$ref": "_terms.yaml#/base_caller_name"
-                },
-                "description": "Name of the base caller.",
-                "type": "string"
-            },
-            "base_caller_version": {
-                "term": {
-                    "$ref": "_terms.yaml#/base_caller_version"
-                },
-                "description": "Version of the base caller.",
-                "type": "string"
-            },
-            "is_paired_end": {
-                "term": {
-                    "$ref": "_terms.yaml#/is_paired_end"
-                },
-                "description": "Are the reads paired end?",
-                "type": "boolean"
-            },
-            "read_length": {
-                "type": "integer",
-                "description": "The length of the reads."
-            },
-            "read_group_name": {
-                "description": "Read group name.",
-                "type": "string"
-            },
-            "barcoding_applied": {
-                "description": "True/False: was barcoding applied?",
-                "type": "boolean"
-            },
-            "chipseq_antibody": {
-                "description": "NEW: The antibody used in the ChIP-Seq assay.",
-                "enum": [
-                    "abcam ab4729 anti-H3K27ac",
-                    "Unknown",
-                    "Not Applicable"
-                ]
-            },
-            "chipseq_target": {
-                "description": "NEW: The antibody used in the ChIP-Seq assay.",
-                "enum": [
-                    "H3K4me1",
-                    "H3K4me3",
-                    "H3K9me3",
-                    "H3K27me3",
-                    "H3K36me3",
-                    "H3K27ac",
-                    "Input Control",
-                    "Unknown"
-                ]
-            },
-            "days_to_sequencing": {
-                "description": "NEW: Number of days between the date used for index and the date the read group was sequenced.",
-                "type": "integer",
-                "minimum": -32872
-            },
-            "fragment_maximum_length": {
-                "description": "NEW: Maximum length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
-                "type": "integer",
-                "minimum": 0
-            },
-            "fragment_mean_length": {
-                "description": "NEW: Mean length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
-                "type": "number",
-                "minimum": 0
-            },
-            "fragment_minimum_length": {
-                "description": "NEW: Minimum length of the sequenced fragments (e.g., as predicted by Agilent Bioanalyzer).",
-                "type": "integer",
-                "minimum": 0
-            },
-            "fragment_standard_deviation_length": {
-                "description": "NEW: Standard deviation of the sequenced fragments length (e.g., as predicted by Agilent Bioanalyzer).",
-                "type": "number",
-                "minimum": 0
-            },
-            "fragmentation_enzyme": {
-                "description": "NEW: The restriction enzyme used for nucleotide fragmentation.",
-                "enum": [
-                    "MboI",
-                    "Unknown",
-                    "Not Applicable"
-                ]
-            },
-            "lane_number": {
-                "description": "NEW: The basic machine unit for sequencing. For Illumina machines, this reflects the physical lane number. Wrong or missing information may affect analysis results.",
-                "type": "integer",
-                "minimum": 1
-            },
-            "multiplex_barcode": {
-                "description": "NEW: The barcode/index sequence used. Wrong or missing information may affect analysis results.",
+            "intended_release_date": {
+                "description": "Tracks a Project's intended release date.",
                 "type": "string",
-                "pattern": "^[0-9ACGTURYSWKMBDHVN]+([\\+\\-][0-9ACGTURYSWKMBDHVN]+){,2}$"
+                "format": "date-time"
             },
-            "number_expect_cells": {
-                "description": "NEW: Expected number of recovered cells in droplet-based single-cell libraries.",
-                "type": "integer",
-                "minimum": 0
-            },
-            "single_cell_library": {
-                "description": "NEW: Library preparation strategy that distinguishes different single-cell assays.",
-                "enum": [
-                    "Chromium 3' Gene Expression v2 Library",
-                    "Chromium 3' Gene Expression v3 Library",
-                    "Chromium scATAC v1 Library",
-                    "Smart-Seq2"
-                ]
-            },
-            "target_capture_kit": {
-                "description": "NEW: Description that can uniquely identify a target capture kit. Suggested value is a combination of vendor, kit name, and kit version.",
-                "enum": [
-                    "Custom AmpliSeq Cancer Hotspot GENIE-MDA Augmented Panel v1 - 46 Genes",
-                    "Custom GENIE-DFCI OncoPanel - 275 Genes",
-                    "Custom GENIE-DFCI Oncopanel - 300 Genes",
-                    "Custom GENIE-DFCI Oncopanel - 447 Genes",
-                    "Custom HaloPlex DLBCL Panel - 370 Genes",
-                    "Custom Ion AmpliSeq Hotspot GENIE-MOSC3 Augmented Panel - 74 Genes",
-                    "Custom Large Construct Capture TARGET-OS Panel - 8 Genes",
-                    "Custom MSK IMPACT Panel - 341 Genes",
-                    "Custom MSK IMPACT Panel - 410 Genes",
-                    "Custom MSK IMPACT Panel - 468 Genes",
-                    "Custom Myeloid GENIE-VICC Panel - 37 Genes",
-                    "Custom Personalis ACEcp VAREPOP-APOLLO Panel v2",
-                    "Custom PGDX SureSelect CancerSelect VAREPOP-APOLLO Panel - 203 Genes",
-                    "Custom PGDX SureSelect CancerSelect VAREPOP-APOLLO Panel - 88 Genes",
-                    "Custom SeqCap EZ BeatAML Panel - 12.5 Mb",
-                    "Custom SeqCap EZ HGSC VCRome v2.1 ER Augmented v1",
-                    "Custom SeqCap EZ HGSC VCRome v2.1 ER Augmented v2",
-                    "Custom SeqCap EZ TARGET-OS Panel - 7.0 Mb",
-                    "Custom Solid Tumor GENIE-VICC Panel - 34 Genes",
-                    "Custom SureSelect CGCI-BLGSP Panel - 4.6 Mb",
-                    "Custom SureSelect CGCI-HTMCP-CC KMT2D And Hotspot Panel - 37.0 Kb",
-                    "Custom SureSelect CGCI-HTMCP-CC Panel - 19.7 Mb",
-                    "Custom SureSelect GENIE-UHN Panel - 555 Genes",
-                    "Custom SureSelect Human All Exon v1.1 Plus 3 Boosters",
-                    "Custom SureSelect TARGET-AML_NBL_WT Panel - 2.8 Mb",
-                    "Custom Twist Broad Exome v1.0 - 35.0 Mb",
-                    "Custom Twist Broad PanCancer Panel - 396 Genes",
-                    "Custom Twist MP2PRT-WT Panel - 52 Kb",
-                    "Foundation Medicine T5a Panel - 322 Genes",
-                    "Foundation Medicine T7 Panel - 429 Genes",
-                    "Ion AmpliSeq Cancer Hotspot Panel v2",
-                    "Ion AmpliSeq Comprehensive Cancer Panel",
-                    "Nextera DNA Exome",
-                    "Nextera Rapid Capture Exome v1.2",
-                    "Not Applicable",
-                    "SeqCap EZ HGSC VCRome v2.1",
-                    "SeqCap EZ Human Exome v2.0",
-                    "SeqCap EZ Human Exome v3.0",
-                    "SureSelect Human All Exon v3",
-                    "SureSelect Human All Exon v4",
-                    "SureSelect Human All Exon v5",
-                    "SureSelect Human All Exon v5 + UTR",
-                    "TruSeq Amplicon Cancer Panel",
-                    "TruSeq Exome Enrichment - 62 Mb",
-                    "TruSeq RNA Exome",
-                    "TruSight Myeloid Sequencing Panel",
-                    "Twist Human Comprehensive Exome",
-                    "xGen Exome Research Panel v1.0",
-                    "Unknown"
-                ]
-            },
-            "aliquots": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
+            "dbgap_accession_number": {
+                "type": "string",
+                "description": "The dbgap accession number provided for the project."
             }
         }
     },
-    "aligned_reads_index.yaml": {
+    "submitted_methylation.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "aligned_reads_index",
-        "title": "Aligned Reads Index",
+        "id": "submitted_methylation",
+        "title": "Submitted Methylation",
         "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "index_file",
+        "namespace": "https://www.bloodpac.org/",
+        "category": "data_file",
         "program": "*",
         "project": "*",
-        "description": "Data file containing the index for a set of aligned reads.",
+        "description": "DNA methylation data files contain information on raw and normalized signal intensities, detection confidence and calculated beta values for methylated and unmethylated probes. DNA methylation is an epigenetic mark which can be associated with transcriptional inactivity when located in promoter regions.",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
@@ -6944,19 +7268,19 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "aligned_reads_indexes",
-                        "label": "derived_from",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
                         "name": "core_metadata_collections",
-                        "backref": "aligned_reads_indexes",
+                        "backref": "submitted_methylation_files",
                         "label": "data_from",
                         "target_type": "core_metadata_collection",
                         "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "aliquots",
+                        "backref": "submitted_methylation_files",
+                        "label": "data_from",
+                        "target_type": "aliquot",
+                        "multiplicity": "many_to_one",
                         "required": false
                     }
                 ]
@@ -6985,9 +7309,150 @@
             "$ref": "_definitions.yaml#/data_file_properties",
             "type": {
                 "enum": [
-                    "aligned_reads_index"
+                    "submitted_methylation"
                 ]
             },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Methylation Data"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Methylation Intensity Values"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "IDAT"
+                ]
+            },
+            "assay_method": {
+                "enum": [
+                    "Methylation Array"
+                ]
+            },
+            "assay_instrument": {
+                "enum": [
+                    "Illumina"
+                ]
+            },
+            "assay_instrument_model": {
+                "enum": [
+                    "Illumina Infinium HumanMethylation450",
+                    "Illumina Infinium HumanMethylation450K"
+                ]
+            },
+            "aliquots": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "aligned_reads.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "aligned_reads",
+        "title": "Aligned Reads",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "data_file",
+        "program": "*",
+        "project": "*",
+        "description": "Data file containing aligned reads that are generated internally by the GDC.\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "aligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "alignment_cocleaning_workflows",
+                        "backref": "aligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "alignment_cocleaning_workflow",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "alignment_workflows",
+                        "backref": "aligned_reads_files",
+                        "label": "data_from",
+                        "target_type": "alignment_workflow",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_unaligned_reads_files",
+                        "backref": "aligned_reads_files",
+                        "label": "matched_to",
+                        "target_type": "submitted_unaligned_reads",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "aligned_reads_files",
+                        "label": "matched_to",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format",
+            "experimental_strategy",
+            "platform"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
             "data_category": {
                 "term": {
                     "$ref": "_terms.yaml#/data_category"
@@ -7003,18 +7468,43 @@
                     "$ref": "_terms.yaml#/data_type"
                 },
                 "enum": [
-                    "Aligned Reads Index"
+                    "Aligned Reads"
                 ]
             },
             "data_format": {
                 "term": {
                     "$ref": "_terms.yaml#/data_format"
                 },
-                "description": "UPDATED: Format of the data files.",
                 "enum": [
-                    "BAI",
-                    "CRAI"
+                    "BAM",
+                    "CRAM"
                 ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "Low Pass WGS",
+                    "Validation",
+                    "RNA-Seq",
+                    "miRNA-Seq",
+                    "Total RNA-Seq"
+                ]
+            },
+            "platform": {
+                "$ref": "read_group.yaml#/properties/platform"
+            },
+            "alignment_cocleaning_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "alignment_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "submitted_unaligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
             },
             "submitted_aligned_reads_files": {
                 "$ref": "_definitions.yaml#/to_one"
@@ -7024,331 +7514,64 @@
             }
         }
     },
-    "demographic.yaml": {
+    "submitted_genomic_profile.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "demographic",
-        "title": "Demographic",
+        "id": "submitted_genomic_profile",
+        "title": "Submitted Genomic Profile",
         "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "clinical",
-        "program": "*",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
         "project": "*",
-        "description": "Data for the characterization of the patient by means of segementing the population (e.g., characterization by age, sex, or race).\n",
+        "program": "*",
+        "description": "Data file containing genomic profile information.",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
         "systemProperties": [
             "id",
             "project_id",
-            "state",
             "created_datetime",
-            "updated_datetime"
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
         ],
-        "links": [
-            {
-                "name": "cases",
-                "backref": "demographics",
-                "label": "describes",
-                "target_type": "case",
-                "multiplicity": "one_to_one",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "cases"
-        ],
-        "preferred": [
-            "year_of_death"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "type": "string"
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "ethnicity": {
-                "description": "An individual's self-described social and cultural grouping, specifically whether an individual describes themselves as Hispanic or Latino. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
-                "enum": [
-                    "hispanic or latino",
-                    "not hispanic or latino",
-                    "Unknown",
-                    "not reported",
-                    "not allowed to collect",
-                    "None"
-                ]
-            },
-            "sex": {
-                "description": "Sex of patient at birth.",
-                "enum": [
-                    "male",
-                    "female",
-                    "unknown",
-                    "unspecified"
-                ]
-            },
-            "gender": {
-                "description": "Text designations that identify gender. Gender is described as the assemblage of properties that distinguish people on the basis of their societal roles. [Explanatory Comment 1: Identification of gender is based upon self-report and may come from a form, questionnaire, interview, etc.]",
-                "enum": [
-                    "female",
-                    "male",
-                    "unknown",
-                    "unspecified",
-                    "not reported",
-                    "None"
-                ]
-            },
-            "race": {
-                "description": "An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.",
-                "enum": [
-                    "white",
-                    "american indian or alaska native",
-                    "black or african american",
-                    "asian",
-                    "native hawaiian or other pacific islander",
-                    "other",
-                    "Unknown",
-                    "More than one race",
-                    "not reported",
-                    "not allowed to contact",
-                    "None"
-                ]
-            },
-            "education": {
-                "description": "Text term to identify the highest level of education complete for the patient.",
-                "type": [
-                    "string"
-                ]
-            },
-            "marital": {
-                "description": "What is your current marital status?",
-                "enum": [
-                    "Divorced",
-                    "Domestic Partnership",
-                    "Married",
-                    "Never Married",
-                    "Separated",
-                    "Widowed",
-                    "Missing",
-                    "Living with significant other (common law marriage)",
-                    "Single, never married"
-                ]
-            },
-            "cur_employ_stat": {
-                "description": "The indicator to ask if the patient is currently employed.",
-                "enum": [
-                    "No",
-                    "Not sure",
-                    "Missing",
-                    "Yes"
-                ]
-            },
-            "vital_status": {
-                "description": "The survival state of the person registered on the protocol.",
-                "enum": [
-                    "Alive",
-                    "Dead",
-                    "Unknown",
-                    "Not Reported",
-                    "None"
-                ]
-            },
-            "age_at_index": {
-                "description": "The patient's age (in years) on the reference or anchor date date used during date obfuscation.",
-                "type": [
-                    "number",
-                    "null"
-                ]
-            },
-            "year_of_birth": {
-                "description": "Numeric value to represent the calendar year in which an individual was born.",
-                "type": [
-                    "number",
-                    "null"
-                ]
-            },
-            "days_to_death": {
-                "description": "Number of days between the date used for index and the date from a person's date of death represented as a calculated number of days.",
-                "type": [
-                    "number"
-                ]
-            },
-            "year_of_death": {
-                "description": "Numeric value to represent the year of the death of an individual.",
-                "type": [
-                    "number"
-                ]
-            },
-            "cause_of_death_primary": {
-                "description": "Text term to identify the primary cause of death for a patient.",
-                "type": [
-                    "string"
-                ]
-            },
-            "cause_of_death_secondary": {
-                "description": "Text term to identify the secondary cause of death for a patient.",
-                "type": [
-                    "string"
-                ]
-            },
-            "death_related_to": {
-                "description": "Text term to identify common conditions to which the death is related.",
-                "enum": [
-                    "Spontaneous Bacterial Peritonitis",
-                    "Sepsis",
-                    "Esophageal Variceal Bleed",
-                    "Gastric Variceal Bleeding",
-                    "Liver Disease - Other",
-                    "Unknown",
-                    "Other"
-                ]
-            },
-            "cases": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "submitted_copy_number.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "additionalProperties": false,
-        "category": "data_file",
-        "description": "Data file containing normalized copy number information from an aliquot.\n",
-        "id": "submitted_copy_number",
         "links": [
             {
                 "exclusive": false,
                 "required": true,
                 "subgroup": [
                     {
-                        "backref": "submitted_copy_number_files",
-                        "label": "data_from",
+                        "name": "read_groups",
+                        "backref": "submitted_genomic_profiles",
+                        "label": "derived_from",
+                        "target_type": "read_group",
                         "multiplicity": "many_to_many",
-                        "name": "core_metadata_collections",
-                        "required": false,
-                        "target_type": "core_metadata_collection"
+                        "required": true
                     },
                     {
-                        "exclusive": true,
-                        "required": false,
-                        "subgroup": [
-                            {
-                                "backref": "submitted_copy_number_files",
-                                "label": "derived_from",
-                                "multiplicity": "one_to_one",
-                                "name": "aliquots",
-                                "required": false,
-                                "target_type": "aliquot"
-                            },
-                            {
-                                "backref": "submitted_copy_number_files",
-                                "label": "derived_from",
-                                "multiplicity": "many_to_many",
-                                "name": "read_groups",
-                                "required": false,
-                                "target_type": "read_group"
-                            }
-                        ]
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_genomic_profiles",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
                     }
                 ]
             }
         ],
-        "namespace": "http://gdc.nci.nih.gov",
-        "program": "*",
-        "project": "*",
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "aliquots": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "type": "string"
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "type": "string"
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "type": "string"
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "type": "string"
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "type": {
-                "enum": [
-                    "submitted_copy_number"
-                ]
-            }
-        },
         "required": [
-            "submitter_id",
             "type",
+            "submitter_id",
             "file_name",
             "file_size",
-            "data_format",
             "md5sum",
             "data_category",
+            "data_format",
             "data_type",
-            "experimental_strategy"
+            "experimental_strategy",
+            "read_groups"
         ],
-        "submittable": true,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "title": "Submitted Copy Number",
-        "type": "object",
         "uniqueKeys": [
             [
                 "id"
@@ -7358,18 +7581,76 @@
                 "submitter_id"
             ]
         ],
-        "validators": null
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "submitted_genomic_profile"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Combined Nucleotide Variation",
+                    "Genomic Profiling"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "FoundationOne Report",
+                    "GENIE Report",
+                    "Raw CGI Variant"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "MAF",
+                    "TSV",
+                    "VCF",
+                    "XML"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "ATAC-Seq",
+                    "Bisulfite-Seq",
+                    "ChIP-Seq",
+                    "miRNA-Seq",
+                    "RNA-Seq",
+                    "Targeted Sequencing",
+                    "WGS",
+                    "WXS"
+                ]
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
     },
-    "copy_number_segment.yaml": {
+    "copy_number_auxiliary_file.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "copy_number_segment",
-        "title": "Copy Number Segment",
+        "id": "copy_number_auxiliary_file",
+        "title": "Copy Number Auxiliary File",
         "type": "object",
         "namespace": "https://gdc.cancer.gov",
         "category": "data_file",
         "project": "*",
         "program": "*",
-        "description": "Data file containing the copy number data from a copy number liftover workflow. Contains all copy numbers detected.",
+        "description": "Data file related to the copy number pipeline that contains any outputs not strictly defined in other nodes",
         "additionalProperties": false,
         "submittable": false,
         "validators": null,
@@ -7388,35 +7669,19 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "core_metadata_collections",
-                        "backref": "copy_number_segments",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "copy_number_liftover_workflows",
-                        "backref": "copy_number_segments",
-                        "label": "derived_from",
-                        "target_type": "copy_number_liftover_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "genomic_profile_harmonization_workflows",
-                        "backref": "copy_number_segments",
-                        "label": "derived_from",
-                        "target_type": "genomic_profile_harmonization_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
                         "name": "somatic_copy_number_workflows",
-                        "backref": "copy_number_segments",
+                        "backref": "copy_number_auxiliary_files",
                         "label": "derived_from",
                         "target_type": "somatic_copy_number_workflow",
                         "multiplicity": "one_to_one",
+                        "required": true
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "copy_number_auxiliary_files",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "one_to_many",
                         "required": false
                     }
                 ]
@@ -7458,9 +7723,7 @@
                     "$ref": "_terms.yaml#/data_type"
                 },
                 "enum": [
-                    "Allele-specific Copy Number Segment",
-                    "Copy Number Segment",
-                    "Masked Copy Number Segment"
+                    "Intermediate Analysis Archive"
                 ]
             },
             "data_format": {
@@ -7468,7 +7731,7 @@
                     "$ref": "_terms.yaml#/data_format"
                 },
                 "enum": [
-                    "TXT"
+                    "TAR"
                 ]
             },
             "experimental_strategy": {
@@ -7476,10 +7739,7 @@
                     "$ref": "_terms.yaml#/experimental_strategy"
                 },
                 "enum": [
-                    "Genotyping Array",
-                    "Targeted Sequencing",
-                    "WGS",
-                    "WXS"
+                    "WGS"
                 ]
             },
             "platform": {
@@ -7487,210 +7747,13 @@
                     "$ref": "_terms.yaml#/platform"
                 },
                 "enum": [
-                    "Affymetrix SNP 6.0",
                     "Illumina"
                 ]
             },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "copy_number_liftover_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "genomic_profile_harmonization_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
             "somatic_copy_number_workflows": {
                 "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "study.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "study",
-        "title": "Study",
-        "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "administrative",
-        "program": "*",
-        "project": "*",
-        "description": "The study node. \n",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "state",
-            "created_datetime",
-            "updated_datetime"
-        ],
-        "links": [
-            {
-                "name": "projects",
-                "backref": "studies",
-                "label": "member_of",
-                "target_type": "project",
-                "multiplicity": "many_to_one",
-                "required": true
-            }
-        ],
-        "required": [
-            "submitter_id",
-            "type",
-            "projects",
-            "study_name"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "type": {
-                "type": "string"
             },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "study_name": {
-                "type": [
-                    "string"
-                ]
-            },
-            "study_type": {
-                "description": "The type of the study, observational or clinical",
-                "enum": [
-                    "obs",
-                    "clinical"
-                ]
-            },
-            "data_description": {
-                "description": "Brief description of the data being provided for this study. Free text.",
-                "type": [
-                    "string"
-                ]
-            },
-            "study_description": {
-                "description": "A brief description of the study being performed. Free text.",
-                "type": [
-                    "string"
-                ]
-            },
-            "type_of_data": {
-                "description": "Is the data raw or processed?",
-                "enum": [
-                    "Raw",
-                    "Processed",
-                    "Raw/ Processed"
-                ]
-            },
-            "projects": {
-                "$ref": "_definitions.yaml#/to_one_project"
-            },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            }
-        }
-    },
-    "alignment_cocleaning_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "alignment_cocleaning_workflow",
-        "title": "Alignment Cocleaning Workflow",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "analysis",
-        "program": "*",
-        "project": "*",
-        "description": "Metadata for the alignment and cocleaning pipeline used to align reads in the GDC harmonization pipelines.\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "alignment_cocleaning_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_unaligned_reads_files",
-                        "backref": "alignment_cocleaning_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_unaligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "workflow_link",
-            "workflow_type"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "type": {
-                "enum": [
-                    "alignment_cocleaning_workflow"
-                ]
-            },
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "BWA with Mark Duplicates and Cocleaning"
-                ]
-            },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "submitted_unaligned_reads_files": {
+            "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
             }
         }
@@ -8536,16 +8599,16 @@
             }
         }
     },
-    "copy_number_auxiliary_file.yaml": {
+    "copy_number_variation_workflow.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "copy_number_auxiliary_file",
-        "title": "Copy Number Auxiliary File",
+        "id": "copy_number_variation_workflow",
+        "title": "Copy Number Variation Workflow",
         "type": "object",
         "namespace": "https://gdc.cancer.gov",
-        "category": "data_file",
+        "category": "analysis",
         "project": "*",
         "program": "*",
-        "description": "Data file related to the copy number pipeline that contains any outputs not strictly defined in other nodes",
+        "description": "Metadata for the Copy Number Variation pipeline used to estimate copy number changes from different molecular data sources.",
         "additionalProperties": false,
         "submittable": false,
         "validators": null,
@@ -8554,45 +8617,23 @@
             "project_id",
             "created_datetime",
             "updated_datetime",
-            "file_state",
-            "state",
-            "error_type"
+            "state"
         ],
         "links": [
             {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "somatic_copy_number_workflows",
-                        "backref": "copy_number_auxiliary_files",
-                        "label": "derived_from",
-                        "target_type": "somatic_copy_number_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": true
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "copy_number_auxiliary_files",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
+                "name": "copy_number_segments",
+                "backref": "copy_number_variation_workflows",
+                "label": "performed_on",
+                "target_type": "copy_number_segment",
+                "multiplicity": "many_to_many",
+                "required": true
             }
         ],
         "required": [
             "type",
             "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy",
-            "platform"
+            "workflow_link",
+            "workflow_type"
         ],
         "uniqueKeys": [
             [
@@ -8604,65 +8645,33 @@
             ]
         ],
         "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "workflow_type": {
                 "term": {
-                    "$ref": "_terms.yaml#/data_category"
+                    "$ref": "_terms.yaml#/workflow_type"
                 },
                 "enum": [
-                    "Copy Number Variation"
+                    "GISTIC - Copy Number Score",
+                    "GISTIC - Arm Level Copy Number",
+                    "GISTIC - Focal Deletion",
+                    "GISTIC - Focal Amplification"
                 ]
             },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Intermediate Analysis Archive"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "TAR"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "WGS"
-                ]
-            },
-            "platform": {
-                "term": {
-                    "$ref": "_terms.yaml#/platform"
-                },
-                "enum": [
-                    "Illumina"
-                ]
-            },
-            "somatic_copy_number_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
+            "copy_number_segments": {
                 "$ref": "_definitions.yaml#/to_many"
             }
         }
     },
-    "germline_mutation_calling_workflow.yaml": {
+    "copy_number_liftover_workflow.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "germline_mutation_calling_workflow",
-        "title": "Germline Mutation Calling Workflow",
+        "id": "copy_number_liftover_workflow",
+        "title": "Copy Number Liftover Workflow",
         "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
+        "namespace": "https://gdc.cancer.gov",
         "category": "analysis",
-        "program": "*",
         "project": "*",
-        "description": "Metadata for the germline mutation calling pipeline used to call variants in the GDC DNA-Seq pipelines.\n",
+        "program": "*",
+        "description": "Metadata for the copy number liftover workflow used to harmonize TCGA copy number data.",
         "additionalProperties": false,
         "submittable": false,
         "validators": null,
@@ -8679,19 +8688,93 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "germline_mutation_calling_workflows",
+                        "name": "submitted_tangent_copy_numbers",
+                        "backref": "copy_number_liftover_workflows",
                         "label": "performed_on",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "many_to_many",
+                        "target_type": "submitted_tangent_copy_number",
+                        "multiplicity": "one_to_one",
+                        "required": true
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_link",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "DNAcopy"
+                ]
+            },
+            "submitted_tangent_copy_numbers": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "rna_expression_calling_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "rna_expression_calling_workflow",
+        "title": "RNA Expression Calling Workflow",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "analysis",
+        "project": "*",
+        "program": "*",
+        "description": "Metadata for the RNA expression pipeline used to quantify RNA gene and exon expression from unharmonized or GDC harmonized data.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "aligned_reads_files",
+                        "backref": "rna_expression_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "aligned_reads",
+                        "multiplicity": "many_to_one",
                         "required": false
                     },
                     {
-                        "name": "aligned_reads_files",
-                        "backref": "germline_mutation_calling_workflows",
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "rna_expression_calling_workflows",
                         "label": "performed_on",
-                        "target_type": "aligned_reads",
-                        "multiplicity": "many_to_many",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_unaligned_reads_files",
+                        "backref": "rna_expression_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_unaligned_reads",
+                        "multiplicity": "many_to_one",
                         "required": false
                     }
                 ]
@@ -8716,7 +8799,7 @@
             "$ref": "_definitions.yaml#/workflow_properties",
             "type": {
                 "enum": [
-                    "germline_mutation_calling_workflow"
+                    "rna_expression_calling_workflow"
                 ]
             },
             "workflow_type": {
@@ -8724,14 +8807,33 @@
                     "$ref": "_terms.yaml#/workflow_type"
                 },
                 "enum": [
-                    "HaplotypeCaller"
+                    "CellRanger - 10x Filtered Counts",
+                    "CellRanger - 10x Raw Counts",
+                    "Cufflinks",
+                    "DEXSeq",
+                    "HTSeq - Counts",
+                    "HTSeq - FPKM",
+                    "HTSeq - FPKM-UQ",
+                    "Kallisto - HDF5",
+                    "Kallisto - Quantification",
+                    "RNA-SeQC - Counts",
+                    "RNA-SeQC - FPKM",
+                    "RSEM - Quantification",
+                    "STAR - Counts",
+                    "STAR - FPKM",
+                    "STAR - Smart-Seq2 Raw Counts",
+                    "STAR - Smart-Seq2 Filtered Counts",
+                    "zUMIs - Smart-Seq2 Counts"
                 ]
             },
             "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
+                "$ref": "_definitions.yaml#/to_one"
             },
             "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "submitted_unaligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_one"
             }
         }
     },
@@ -8850,6 +8952,1203 @@
             },
             "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "simple_germline_variation.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "simple_germline_variation",
+        "title": "Simple Germline Variation",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "data_file",
+        "program": "*",
+        "project": "*",
+        "description": "Data file containing simple germline variations called from aligned reads.\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "simple_germline_variations",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "germline_mutation_calling_workflows",
+                        "backref": "simple_germline_variations",
+                        "label": "data_from",
+                        "target_type": "germline_mutation_calling_workflow",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "read_groups",
+                        "backref": "simple_germline_variations",
+                        "label": "data_from",
+                        "target_type": "read_group",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "simple_germline_variations",
+                        "label": "data_from",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "aligned_reads_files",
+                        "backref": "simple_germline_variations",
+                        "label": "data_from",
+                        "target_type": "aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format",
+            "experimental_strategy"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Simple Nucleotide Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Simple Germline Variation"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "VCF"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "Low Pass WGS",
+                    "Validation"
+                ]
+            },
+            "germline_mutation_calling_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "read_groups": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "submitted_tangent_copy_number.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "submitted_tangent_copy_number",
+        "title": "Submitted Tangent Copy Number",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing tangent normalized copy number information from an aliquot.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "aliquots",
+                        "backref": "submitted_tangent_copy_number",
+                        "label": "derived_from",
+                        "target_type": "aliquot",
+                        "multiplicity": "one_to_one",
+                        "required": true
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_tangent_copy_number",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type",
+            "experimental_strategy"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Copy Number Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Copy Number Estimate"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "TXT"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "Genotyping Array"
+                ]
+            },
+            "aliquots": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "genomic_profile_harmonization_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "genomic_profile_harmonization_workflow",
+        "title": "Genomic Profile Harmonization Workflow",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "analysis",
+        "project": "*",
+        "program": "*",
+        "description": "Metadata for the harmonization of genomic profiling reports.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "submitted_genomic_profiles",
+                        "backref": "genomic_profile_harmonization_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_genomic_profile",
+                        "multiplicity": "many_to_one",
+                        "required": true
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_link",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "FM Copy Number Variation",
+                    "FM Simple Somatic Mutation",
+                    "FM Structural Variation",
+                    "GENIE Copy Number Variation",
+                    "GENIE Simple Somatic Mutation",
+                    "GENIE Structural Variation",
+                    "MuTect2",
+                    "VCF LiftOver"
+                ]
+            },
+            "submitted_genomic_profiles": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "copy_number_estimate.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "copy_number_estimate",
+        "title": "Copy Number Estimate",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing copy number variation information generated internally by the GDC.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "copy_number_variation_workflows",
+                        "backref": "copy_number_estimates",
+                        "label": "derived_from",
+                        "target_type": "copy_number_variation_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "genomic_profile_harmonization_workflows",
+                        "backref": "copy_number_estimates",
+                        "label": "derived_from",
+                        "target_type": "genomic_profile_harmonization_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "somatic_copy_number_workflows",
+                        "backref": "copy_number_estimates",
+                        "label": "derived_from",
+                        "target_type": "somatic_copy_number_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "copy_number_estimates",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type",
+            "experimental_strategy",
+            "platform"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Copy Number Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Gene Level Copy Number",
+                    "Gene Level Copy Number Scores",
+                    "Cohort Level Copy Number Scores"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "TSV",
+                    "TXT"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "Genotyping Array",
+                    "Targeted Sequencing",
+                    "WGS",
+                    "WXS"
+                ]
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "enum": [
+                    "Affymetrix SNP 6.0",
+                    "Illumina",
+                    "Ion Torrent"
+                ]
+            },
+            "copy_number_variation_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "genomic_profile_harmonization_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "somatic_copy_number_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "submitted_genotyping_array.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "submitted_genotyping_array",
+        "title": "Submitted Genotyping Array",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing raw data from a genotyping array.",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "aliquots",
+                        "backref": "submitted_genotyping_arrays",
+                        "label": "derived_from",
+                        "target_type": "aliquot",
+                        "multiplicity": "many_to_one",
+                        "required": true
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "submitted_genotyping_arrays",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type",
+            "experimental_strategy",
+            "platform"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Copy Number Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Raw Intensities"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "CEL"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "Genotyping Array"
+                ]
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "enum": [
+                    "Affymetrix SNP 6.0"
+                ]
+            },
+            "aliquots": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "protein_expression.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "protein_expression",
+        "title": "Protein Expression",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing proteomics data.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "downloadable": true,
+        "previous_version_downloadable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "protein_expressions",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "labs",
+                        "backref": "protein_expressions",
+                        "label": "produced_by",
+                        "target_type": "lab",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "submitter_id",
+            "type",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "data_format"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "protein_expression"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "type": [
+                    "string"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "description": "The experimental strategy used to generate the data file.",
+                "enum": [
+                    "Reverse Phase Protein Array",
+                    "LC-MS/MS",
+                    "TMT",
+                    "Label-Free",
+                    "DIA",
+                    "DDA",
+                    "SWATH"
+                ]
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "measurement_type": {
+                "description": "The type of quantification measurement in the data file.",
+                "enum": [
+                    "pep",
+                    "Quantity",
+                    "Spectral_Count",
+                    "iBAQ"
+                ]
+            },
+            "instrument_model": {
+                "description": "The model of mass spectrometry instrument used (e.g. Orbitrap Exploris 480).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "software_version": {
+                "description": "The software and version used for data processing (e.g. MaxQuant 2.1.0).",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "labs": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "structural_variant_calling_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "structural_variant_calling_workflow",
+        "title": "Structural Variant Calling Workflow",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "analysis",
+        "project": "*",
+        "program": "*",
+        "description": "Metadata for the structural variant calling pipeline used to call structural variants in the GDC DNA-Seq or RNA-Seq pipelines.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "name": "aligned_reads_files",
+                "backref": "structural_variant_calling_workflows",
+                "label": "performed_on",
+                "target_type": "aligned_reads",
+                "multiplicity": "many_to_many",
+                "required": true
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_link",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "Arriba",
+                    "BRASS",
+                    "Fusion Catcher",
+                    "Pizzly",
+                    "STAR-Fusion",
+                    "SvABA"
+                ]
+            },
+            "aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "alignment_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "alignment_workflow",
+        "title": "Alignment Workflow",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "analysis",
+        "program": "*",
+        "project": "*",
+        "description": "Metadata for the alignment pipeline used to align reads in the GDC harmonization pipelines.\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "alignment_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "submitted_unaligned_reads_files",
+                        "backref": "alignment_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_unaligned_reads",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "type": {
+                "enum": [
+                    "alignment_workflow"
+                ]
+            },
+            "workflow_type": {
+                "enum": [
+                    "STAR",
+                    "BWA-aln",
+                    "BWA-mem",
+                    "spinnaker"
+                ]
+            },
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "submitted_unaligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "germline_mutation_calling_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "germline_mutation_calling_workflow",
+        "title": "Germline Mutation Calling Workflow",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "analysis",
+        "program": "*",
+        "project": "*",
+        "description": "Metadata for the germline mutation calling pipeline used to call variants in the GDC DNA-Seq pipelines.\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "germline_mutation_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "aligned_reads_files",
+                        "backref": "germline_mutation_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_link",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "type": {
+                "enum": [
+                    "germline_mutation_calling_workflow"
+                ]
+            },
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "HaplotypeCaller"
+                ]
+            },
+            "aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "copy_number_segment.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "copy_number_segment",
+        "title": "Copy Number Segment",
+        "type": "object",
+        "namespace": "https://gdc.cancer.gov",
+        "category": "data_file",
+        "project": "*",
+        "program": "*",
+        "description": "Data file containing the copy number data from a copy number liftover workflow. Contains all copy numbers detected.",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "copy_number_segments",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "copy_number_liftover_workflows",
+                        "backref": "copy_number_segments",
+                        "label": "derived_from",
+                        "target_type": "copy_number_liftover_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "genomic_profile_harmonization_workflows",
+                        "backref": "copy_number_segments",
+                        "label": "derived_from",
+                        "target_type": "genomic_profile_harmonization_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "somatic_copy_number_workflows",
+                        "backref": "copy_number_segments",
+                        "label": "derived_from",
+                        "target_type": "somatic_copy_number_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type",
+            "experimental_strategy",
+            "platform"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Copy Number Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Allele-specific Copy Number Segment",
+                    "Copy Number Segment",
+                    "Masked Copy Number Segment"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "TXT"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "Genotyping Array",
+                    "Targeted Sequencing",
+                    "WGS",
+                    "WXS"
+                ]
+            },
+            "platform": {
+                "term": {
+                    "$ref": "_terms.yaml#/platform"
+                },
+                "enum": [
+                    "Affymetrix SNP 6.0",
+                    "Illumina"
+                ]
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "copy_number_liftover_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "genomic_profile_harmonization_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "somatic_copy_number_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            }
+        }
+    },
+    "mirna_expression_calling_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "mirna_expression_calling_workflow",
+        "title": "miRNA Expression Calling Workflow",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "analysis",
+        "program": "*",
+        "project": "*",
+        "description": "Metadata for the miRNA expression calling pipeline.\n",
+        "additionalProperties": false,
+        "submittable": false,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "mirna_expression_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "aligned_reads_files",
+                        "backref": "mirna_expression_calling_workflows",
+                        "label": "performed_on",
+                        "target_type": "aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "workflow_link",
+            "workflow_type"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/workflow_properties",
+            "type": {
+                "enum": [
+                    "germline_mutation_calling_workflow"
+                ]
+            },
+            "workflow_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/workflow_type"
+                },
+                "enum": [
+                    "HaplotypeCaller"
+                ]
+            },
+            "aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "submitted_aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
             }
         }
     },
@@ -9038,184 +10337,41 @@
             }
         }
     },
-    "structural_variation.yaml": {
+    "study.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "structural_variation",
-        "title": "structural_variation",
+        "id": "study",
+        "title": "Study",
         "type": "object",
         "namespace": "http://gdc.nci.nih.gov",
-        "category": "data_file",
+        "category": "administrative",
         "program": "*",
         "project": "*",
-        "description": "Structural_variation reads that are used as input to GDC workflows.\n",
+        "description": "The study node. \n",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
         "systemProperties": [
             "id",
             "project_id",
-            "created_datetime",
-            "updated_datetime",
             "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "genomic_profile_harmonization_workflows",
-                        "backref": "structural_variations",
-                        "label": "data_from",
-                        "target_type": "genomic_profile_harmonization_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "structural_variant_calling_workflows",
-                        "backref": "structural_variations",
-                        "label": "data_from",
-                        "target_type": "structural_variant_calling_workflow",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "structural_variations",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "data_format",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "experimental_strategy"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "aligned_reads"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Somatic Structural Variation",
-                    "Structural Variation"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Structural Alteration",
-                    "Structural Rearrangement",
-                    "Transcript Fusion"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "BAM",
-                    "BEDPE",
-                    "CSV",
-                    "FASTA",
-                    "GVF",
-                    "JSON",
-                    "TSV",
-                    "TXT",
-                    "VCF"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "Low Pass WGS",
-                    "Validation",
-                    "RNA-Seq",
-                    "miRNA-Seq",
-                    "Targeted Sequencing",
-                    "Total RNA-Seq",
-                    "DNA Panel"
-                ]
-            },
-            "genomic_profile_harmonization_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "structural_variant_calling_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "copy_number_variation_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "copy_number_variation_workflow",
-        "title": "Copy Number Variation Workflow",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "analysis",
-        "project": "*",
-        "program": "*",
-        "description": "Metadata for the Copy Number Variation pipeline used to estimate copy number changes from different molecular data sources.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
             "created_datetime",
-            "updated_datetime",
-            "state"
+            "updated_datetime"
         ],
         "links": [
             {
-                "name": "copy_number_segments",
-                "backref": "copy_number_variation_workflows",
-                "label": "performed_on",
-                "target_type": "copy_number_segment",
-                "multiplicity": "many_to_many",
+                "name": "projects",
+                "backref": "studies",
+                "label": "member_of",
+                "target_type": "project",
+                "multiplicity": "many_to_one",
                 "required": true
             }
         ],
         "required": [
-            "type",
             "submitter_id",
-            "workflow_link",
-            "workflow_type"
+            "type",
+            "projects",
+            "study_name"
         ],
         "uniqueKeys": [
             [
@@ -9227,845 +10383,101 @@
             ]
         ],
         "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "GISTIC - Copy Number Score",
-                    "GISTIC - Arm Level Copy Number",
-                    "GISTIC - Focal Deletion",
-                    "GISTIC - Focal Amplification"
-                ]
-            },
-            "copy_number_segments": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "copy_number_estimate.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "copy_number_estimate",
-        "title": "Copy Number Estimate",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "data_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing copy number variation information generated internally by the GDC.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "file_state",
-            "state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "copy_number_variation_workflows",
-                        "backref": "copy_number_estimates",
-                        "label": "derived_from",
-                        "target_type": "copy_number_variation_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "genomic_profile_harmonization_workflows",
-                        "backref": "copy_number_estimates",
-                        "label": "derived_from",
-                        "target_type": "genomic_profile_harmonization_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "somatic_copy_number_workflows",
-                        "backref": "copy_number_estimates",
-                        "label": "derived_from",
-                        "target_type": "somatic_copy_number_workflow",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "copy_number_estimates",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy",
-            "platform"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Copy Number Variation"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Gene Level Copy Number",
-                    "Gene Level Copy Number Scores",
-                    "Cohort Level Copy Number Scores"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "TSV",
-                    "TXT"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "Genotyping Array",
-                    "Targeted Sequencing",
-                    "WGS",
-                    "WXS"
-                ]
-            },
-            "platform": {
-                "term": {
-                    "$ref": "_terms.yaml#/platform"
-                },
-                "enum": [
-                    "Affymetrix SNP 6.0",
-                    "Illumina",
-                    "Ion Torrent"
-                ]
-            },
-            "copy_number_variation_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "genomic_profile_harmonization_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "somatic_copy_number_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "mirna_expression_calling_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "mirna_expression_calling_workflow",
-        "title": "miRNA Expression Calling Workflow",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "analysis",
-        "program": "*",
-        "project": "*",
-        "description": "Metadata for the miRNA expression calling pipeline.\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "mirna_expression_calling_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "aligned_reads_files",
-                        "backref": "mirna_expression_calling_workflows",
-                        "label": "performed_on",
-                        "target_type": "aligned_reads",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "workflow_link",
-            "workflow_type"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
             "type": {
-                "enum": [
-                    "germline_mutation_calling_workflow"
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
                 ]
             },
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "HaplotypeCaller"
+            "study_name": {
+                "type": [
+                    "string"
                 ]
             },
-            "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
+            "study_type": {
+                "description": "The type of the study, observational or clinical",
+                "enum": [
+                    "obs",
+                    "clinical"
+                ]
             },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
+            "data_description": {
+                "description": "Brief description of the data being provided for this study. Free text.",
+                "type": [
+                    "string"
+                ]
+            },
+            "study_description": {
+                "description": "A brief description of the study being performed. Free text.",
+                "type": [
+                    "string"
+                ]
+            },
+            "type_of_data": {
+                "description": "Is the data raw or processed?",
+                "enum": [
+                    "Raw",
+                    "Processed",
+                    "Raw/ Processed"
+                ]
+            },
+            "projects": {
+                "$ref": "_definitions.yaml#/to_one_project"
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
             }
         }
     },
-    "simple_germline_variation.yaml": {
+    "audit.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "simple_germline_variation",
-        "title": "Simple Germline Variation",
+        "id": "audit",
+        "title": "Audit",
         "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "data_file",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "administrative",
         "program": "*",
         "project": "*",
-        "description": "Data file containing simple germline variations called from aligned reads.\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "simple_germline_variations",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "germline_mutation_calling_workflows",
-                        "backref": "simple_germline_variations",
-                        "label": "data_from",
-                        "target_type": "germline_mutation_calling_workflow",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "read_groups",
-                        "backref": "simple_germline_variations",
-                        "label": "data_from",
-                        "target_type": "read_group",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "simple_germline_variations",
-                        "label": "data_from",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "aligned_reads_files",
-                        "backref": "simple_germline_variations",
-                        "label": "data_from",
-                        "target_type": "aligned_reads",
-                        "multiplicity": "many_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format",
-            "experimental_strategy"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Simple Nucleotide Variation"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Simple Germline Variation"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "VCF"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "Low Pass WGS",
-                    "Validation"
-                ]
-            },
-            "germline_mutation_calling_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "rna_expression_calling_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "rna_expression_calling_workflow",
-        "title": "RNA Expression Calling Workflow",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "analysis",
-        "project": "*",
-        "program": "*",
-        "description": "Metadata for the RNA expression pipeline used to quantify RNA gene and exon expression from unharmonized or GDC harmonized data.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "aligned_reads_files",
-                        "backref": "rna_expression_calling_workflows",
-                        "label": "performed_on",
-                        "target_type": "aligned_reads",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "rna_expression_calling_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_unaligned_reads_files",
-                        "backref": "rna_expression_calling_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_unaligned_reads",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "workflow_link",
-            "workflow_type"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "type": {
-                "enum": [
-                    "rna_expression_calling_workflow"
-                ]
-            },
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "CellRanger - 10x Filtered Counts",
-                    "CellRanger - 10x Raw Counts",
-                    "Cufflinks",
-                    "DEXSeq",
-                    "HTSeq - Counts",
-                    "HTSeq - FPKM",
-                    "HTSeq - FPKM-UQ",
-                    "Kallisto - HDF5",
-                    "Kallisto - Quantification",
-                    "RNA-SeQC - Counts",
-                    "RNA-SeQC - FPKM",
-                    "RSEM - Quantification",
-                    "STAR - Counts",
-                    "STAR - FPKM",
-                    "STAR - Smart-Seq2 Raw Counts",
-                    "STAR - Smart-Seq2 Filtered Counts",
-                    "zUMIs - Smart-Seq2 Counts"
-                ]
-            },
-            "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "submitted_unaligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "copy_number_liftover_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "copy_number_liftover_workflow",
-        "title": "Copy Number Liftover Workflow",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "analysis",
-        "project": "*",
-        "program": "*",
-        "description": "Metadata for the copy number liftover workflow used to harmonize TCGA copy number data.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "submitted_tangent_copy_numbers",
-                        "backref": "copy_number_liftover_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_tangent_copy_number",
-                        "multiplicity": "one_to_one",
-                        "required": true
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "workflow_link",
-            "workflow_type"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "DNAcopy"
-                ]
-            },
-            "submitted_tangent_copy_numbers": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "submitted_genomic_profile.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_genomic_profile",
-        "title": "Submitted Genomic Profile",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "data_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing genomic profile information.",
+        "description": "audit to a case.",
         "additionalProperties": false,
         "submittable": true,
         "validators": null,
         "systemProperties": [
             "id",
             "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "file_state",
             "state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "read_groups",
-                        "backref": "submitted_genomic_profiles",
-                        "label": "derived_from",
-                        "target_type": "read_group",
-                        "multiplicity": "many_to_many",
-                        "required": true
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_genomic_profiles",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy",
-            "read_groups"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "type": {
-                "enum": [
-                    "submitted_genomic_profile"
-                ]
-            },
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Combined Nucleotide Variation",
-                    "Genomic Profiling"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "FoundationOne Report",
-                    "GENIE Report",
-                    "Raw CGI Variant"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "MAF",
-                    "TSV",
-                    "VCF",
-                    "XML"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "ATAC-Seq",
-                    "Bisulfite-Seq",
-                    "ChIP-Seq",
-                    "miRNA-Seq",
-                    "RNA-Seq",
-                    "Targeted Sequencing",
-                    "WGS",
-                    "WXS"
-                ]
-            },
-            "read_groups": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "mirna_expression.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "mirna_expression",
-        "title": "miRNA Expression",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "data_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing miRNA expression information  generated internally by the GDC.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
             "created_datetime",
-            "updated_datetime",
-            "file_state",
-            "state",
-            "error_type"
+            "updated_datetime"
         ],
         "links": [
             {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "mirna_expressions",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "mirna_expression_calling_workflows",
-                        "backref": "mirna_expressions",
-                        "label": "data_from",
-                        "target_type": "mirna_expression_calling_workflow",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Transcriptome Profiling"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Isoform Expression Quantification",
-                    "miRNA Expression Quantification",
-                    "Supplementary Files"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "CSV",
-                    "TSV",
-                    "TXT"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "miRNA-Seq"
-                ]
-            },
-            "mirna_expression_calling_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "structural_variant_calling_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "structural_variant_calling_workflow",
-        "title": "Structural Variant Calling Workflow",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "analysis",
-        "project": "*",
-        "program": "*",
-        "description": "Metadata for the structural variant calling pipeline used to call structural variants in the GDC DNA-Seq or RNA-Seq pipelines.",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "name": "aligned_reads_files",
-                "backref": "structural_variant_calling_workflows",
-                "label": "performed_on",
-                "target_type": "aligned_reads",
-                "multiplicity": "many_to_many",
+                "name": "cases",
+                "backref": "audits",
+                "label": "describe",
+                "target_type": "case",
+                "multiplicity": "one_to_one",
                 "required": true
             }
         ],
         "required": [
-            "type",
             "submitter_id",
-            "workflow_link",
-            "workflow_type"
+            "type"
         ],
         "uniqueKeys": [
             [
@@ -10077,143 +10489,302 @@
             ]
         ],
         "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "workflow_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/workflow_type"
-                },
-                "enum": [
-                    "Arriba",
-                    "BRASS",
-                    "Fusion Catcher",
-                    "Pizzly",
-                    "STAR-Fusion",
-                    "SvABA"
+            "type": {
+                "type": "string"
+            },
+            "id": {
+                "$ref": "_definitions.yaml#/UUID",
+                "systemAlias": "node_id"
+            },
+            "state": {
+                "$ref": "_definitions.yaml#/state"
+            },
+            "submitter_id": {
+                "type": [
+                    "string",
+                    "null"
                 ]
             },
-            "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
+            "days_to_test": {
+                "description": "Number of days between the date used for index and the date of the laboratory test.",
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "usaudit_collected": {
+                "description": "The yes/no indicator to describe if the AUDIT was collected at this visit.",
+                "enum": [
+                    "Yes",
+                    "No"
+                ]
+            },
+            "usaudit_completed_by": {
+                "description": "The text term used to describe the person who completed the AUDIT.",
+                "enum": [
+                    "Patient/Study Participant",
+                    "Relative of Patient/Study Participant",
+                    "Friend of Patient/Study Participant",
+                    "Other"
+                ]
+            },
+            "usaudit_q1": {
+                "description": "Thinking about your drinking in the past year, how often do you have a drink containing alcohol?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "2 to 3 times a week",
+                    "4 to 6 times a week",
+                    "Daily"
+                ]
+            },
+            "usaudit_q2": {
+                "description": "Thinking about your drinking in the past year, how many drinks containing alcohol do you have on a typical day you are drinking?",
+                "enum": [
+                    "1 drink",
+                    "2 drinks",
+                    "3 drinks",
+                    "4 drinks",
+                    "5 to 6 drinks",
+                    "7 to 9 drinks",
+                    "10 or more drinks"
+                ]
+            },
+            "usaudit_q3": {
+                "description": "Thinking about your drinking in the past year, how often do you have X (5 for men; 4 for women and men over age 65) or more drinks on one occasion?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "2 to 3 times a week",
+                    "4 to 6 times a week",
+                    "Daily"
+                ]
+            },
+            "usaudit_q4": {
+                "description": "Thinking about your drinking in the past year, how often have you found that you were not able to stop drinking once you had started?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "Daily or almost daily"
+                ]
+            },
+            "usaudit_q5": {
+                "description": "Thinking about your drinking in the past year, how often have you failed to do what was expected of you because of drinking?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "Daily or almost daily"
+                ]
+            },
+            "usaudit_q6": {
+                "description": "Thinking about your drinking in the past year, how often have you needed a drink first thing in the morning to get yourself going after a heavy drinking session?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "Daily or almost daily"
+                ]
+            },
+            "usaudit_q7": {
+                "description": "Thinking about your drinking in the past year, how often have you had a feeling of guilt or remorse after drinking?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "Daily or almost daily"
+                ]
+            },
+            "usaudit_q8": {
+                "description": "Thinking about your drinking in the past year, how often have you been unable to remember what happened the night before because you had been drinking?",
+                "enum": [
+                    "Never",
+                    "Less than monthly",
+                    "Monthly",
+                    "Weekly",
+                    "Daily or almost daily"
+                ]
+            },
+            "usaudit_q9": {
+                "description": "Thinking about your drinking in the past year, have you or someone else been injured because of your drinking?",
+                "enum": [
+                    "No",
+                    "Yes, but not in the past year",
+                    "Yes, during the past year"
+                ]
+            },
+            "usaudit_q10": {
+                "description": "Thinking about your drinking in the past year, has a relative, friend, doctor, or other health care worker been concerned about your drinking and suggested you cut down?",
+                "enum": [
+                    "No",
+                    "Yes, but not in the past year",
+                    "Yes, during the past year"
+                ]
+            },
+            "auditnd": {
+                "description": "auditnd",
+                "enum": [
+                    "No",
+                    "Yes",
+                    "null"
+                ]
+            },
+            "adtcomploth": {
+                "description": "adtcomploth",
+                "type": [
+                    "string",
+                    "null"
+                ]
+            },
+            "adt0101": {
+                "description": "adt0101",
+                "enum": [
+                    "2 to 3 times a week",
+                    "2 to 4 times a month",
+                    "4 or more times a week",
+                    "Monthly or less",
+                    "Never",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0102": {
+                "description": "adt0102",
+                "enum": [
+                    "1 or 2",
+                    "3 or 4",
+                    "5 or 6",
+                    "7 to 9",
+                    "10 or more",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0103": {
+                "description": "adt0103",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0104": {
+                "description": "adt0104",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0105": {
+                "description": "adt0105",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0106": {
+                "description": "adt0106",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0107": {
+                "description": "adt0107",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0108": {
+                "description": "adt0108",
+                "enum": [
+                    "Never",
+                    "Weekly",
+                    "Less than monthly",
+                    "Daily or almost daily",
+                    "Monthly",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0109": {
+                "description": "adt0109",
+                "enum": [
+                    "No",
+                    "Yes, during the last year",
+                    "Yes, but not in the last year",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "adt0110": {
+                "description": "adt0110",
+                "enum": [
+                    "No",
+                    "Yes, during the last year",
+                    "Yes, but not in the last year",
+                    "Not Done/Missing",
+                    "null"
+                ]
+            },
+            "cases": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "project_id": {
+                "$ref": "_definitions.yaml#/project_id"
+            },
+            "created_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
+            },
+            "updated_datetime": {
+                "$ref": "_definitions.yaml#/datetime"
             }
         }
     },
-    "submitted_tangent_copy_number.yaml": {
+    "somatic_copy_number_workflow.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_tangent_copy_number",
-        "title": "Submitted Tangent Copy Number",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "data_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing tangent normalized copy number information from an aliquot.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "file_state",
-            "state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "aliquots",
-                        "backref": "submitted_tangent_copy_number",
-                        "label": "derived_from",
-                        "target_type": "aliquot",
-                        "multiplicity": "one_to_one",
-                        "required": true
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_tangent_copy_number",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Copy Number Variation"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Copy Number Estimate"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "TXT"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "Genotyping Array"
-                ]
-            },
-            "aliquots": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "genomic_profile_harmonization_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "genomic_profile_harmonization_workflow",
-        "title": "Genomic Profile Harmonization Workflow",
+        "id": "somatic_copy_number_workflow",
+        "title": "Somatic Copy Number Workflow",
         "type": "object",
         "namespace": "https://gdc.cancer.gov",
         "category": "analysis",
         "project": "*",
         "program": "*",
-        "description": "Metadata for the harmonization of genomic profiling reports.",
+        "description": "Metadata for the Somatic Copy Number pipeline used to estimate copy number changes from different molecular data sources.",
         "additionalProperties": false,
         "submittable": false,
         "validators": null,
@@ -10230,12 +10801,20 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "submitted_genomic_profiles",
-                        "backref": "genomic_profile_harmonization_workflows",
+                        "name": "submitted_genotyping_arrays",
+                        "backref": "somatic_copy_number_workflows",
                         "label": "performed_on",
-                        "target_type": "submitted_genomic_profile",
-                        "multiplicity": "many_to_one",
-                        "required": true
+                        "target_type": "submitted_genotyping_array",
+                        "multiplicity": "many_to_many",
+                        "required": false
+                    },
+                    {
+                        "name": "aligned_reads_files",
+                        "backref": "somatic_copy_number_workflows",
+                        "label": "performed_on",
+                        "target_type": "aligned_reads",
+                        "multiplicity": "many_to_many",
+                        "required": false
                     }
                 ]
             }
@@ -10262,18 +10841,18 @@
                     "$ref": "_terms.yaml#/workflow_type"
                 },
                 "enum": [
-                    "FM Copy Number Variation",
-                    "FM Simple Somatic Mutation",
-                    "FM Structural Variation",
-                    "GENIE Copy Number Variation",
-                    "GENIE Simple Somatic Mutation",
-                    "GENIE Structural Variation",
-                    "MuTect2",
-                    "VCF LiftOver"
+                    "ABSOLUTE LiftOver",
+                    "ASCAT3",
+                    "ASCAT2",
+                    "AscatNGS",
+                    "GATK4 CNV"
                 ]
             },
-            "submitted_genomic_profiles": {
-                "$ref": "_definitions.yaml#/to_one"
+            "submitted_genotyping_arrays": {
+                "$ref": "_definitions.yaml#/to_many"
+            },
+            "aligned_reads_files": {
+                "$ref": "_definitions.yaml#/to_many"
             }
         }
     },
@@ -11282,39 +11861,62 @@
             }
         }
     },
-    "audit.yaml": {
+    "mirna_expression.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "audit",
-        "title": "Audit",
+        "id": "mirna_expression",
+        "title": "miRNA Expression",
         "type": "object",
-        "namespace": "http://gdc.nci.nih.gov",
-        "category": "administrative",
-        "program": "*",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "data_file",
         "project": "*",
-        "description": "audit to a case.",
+        "program": "*",
+        "description": "Data file containing miRNA expression information  generated internally by the GDC.",
         "additionalProperties": false,
-        "submittable": true,
+        "submittable": false,
         "validators": null,
         "systemProperties": [
             "id",
             "project_id",
-            "state",
             "created_datetime",
-            "updated_datetime"
+            "updated_datetime",
+            "file_state",
+            "state",
+            "error_type"
         ],
         "links": [
             {
-                "name": "cases",
-                "backref": "audits",
-                "label": "describe",
-                "target_type": "case",
-                "multiplicity": "one_to_one",
-                "required": true
+                "exclusive": false,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "mirna_expressions",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "mirna_expression_calling_workflows",
+                        "backref": "mirna_expressions",
+                        "label": "data_from",
+                        "target_type": "mirna_expression_calling_workflow",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    }
+                ]
             }
         ],
         "required": [
+            "type",
             "submitter_id",
-            "type"
+            "file_name",
+            "file_size",
+            "md5sum",
+            "data_category",
+            "data_format",
+            "data_type",
+            "experimental_strategy"
         ],
         "uniqueKeys": [
             [
@@ -11326,302 +11928,204 @@
             ]
         ],
         "properties": {
-            "type": {
-                "type": "string"
-            },
-            "id": {
-                "$ref": "_definitions.yaml#/UUID",
-                "systemAlias": "node_id"
-            },
-            "state": {
-                "$ref": "_definitions.yaml#/state"
-            },
-            "submitter_id": {
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "days_to_test": {
-                "description": "Number of days between the date used for index and the date of the laboratory test.",
-                "type": [
-                    "number",
-                    "null"
-                ]
-            },
-            "usaudit_collected": {
-                "description": "The yes/no indicator to describe if the AUDIT was collected at this visit.",
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
                 "enum": [
-                    "Yes",
-                    "No"
+                    "Transcriptome Profiling"
                 ]
             },
-            "usaudit_completed_by": {
-                "description": "The text term used to describe the person who completed the AUDIT.",
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
                 "enum": [
-                    "Patient/Study Participant",
-                    "Relative of Patient/Study Participant",
-                    "Friend of Patient/Study Participant",
-                    "Other"
+                    "Isoform Expression Quantification",
+                    "miRNA Expression Quantification",
+                    "Supplementary Files"
                 ]
             },
-            "usaudit_q1": {
-                "description": "Thinking about your drinking in the past year, how often do you have a drink containing alcohol?",
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
                 "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "2 to 3 times a week",
-                    "4 to 6 times a week",
-                    "Daily"
+                    "CSV",
+                    "TSV",
+                    "TXT"
                 ]
             },
-            "usaudit_q2": {
-                "description": "Thinking about your drinking in the past year, how many drinks containing alcohol do you have on a typical day you are drinking?",
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
                 "enum": [
-                    "1 drink",
-                    "2 drinks",
-                    "3 drinks",
-                    "4 drinks",
-                    "5 to 6 drinks",
-                    "7 to 9 drinks",
-                    "10 or more drinks"
+                    "miRNA-Seq"
                 ]
             },
-            "usaudit_q3": {
-                "description": "Thinking about your drinking in the past year, how often do you have X (5 for men; 4 for women and men over age 65) or more drinks on one occasion?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "2 to 3 times a week",
-                    "4 to 6 times a week",
-                    "Daily"
-                ]
-            },
-            "usaudit_q4": {
-                "description": "Thinking about your drinking in the past year, how often have you found that you were not able to stop drinking once you had started?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "Daily or almost daily"
-                ]
-            },
-            "usaudit_q5": {
-                "description": "Thinking about your drinking in the past year, how often have you failed to do what was expected of you because of drinking?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "Daily or almost daily"
-                ]
-            },
-            "usaudit_q6": {
-                "description": "Thinking about your drinking in the past year, how often have you needed a drink first thing in the morning to get yourself going after a heavy drinking session?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "Daily or almost daily"
-                ]
-            },
-            "usaudit_q7": {
-                "description": "Thinking about your drinking in the past year, how often have you had a feeling of guilt or remorse after drinking?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "Daily or almost daily"
-                ]
-            },
-            "usaudit_q8": {
-                "description": "Thinking about your drinking in the past year, how often have you been unable to remember what happened the night before because you had been drinking?",
-                "enum": [
-                    "Never",
-                    "Less than monthly",
-                    "Monthly",
-                    "Weekly",
-                    "Daily or almost daily"
-                ]
-            },
-            "usaudit_q9": {
-                "description": "Thinking about your drinking in the past year, have you or someone else been injured because of your drinking?",
-                "enum": [
-                    "No",
-                    "Yes, but not in the past year",
-                    "Yes, during the past year"
-                ]
-            },
-            "usaudit_q10": {
-                "description": "Thinking about your drinking in the past year, has a relative, friend, doctor, or other health care worker been concerned about your drinking and suggested you cut down?",
-                "enum": [
-                    "No",
-                    "Yes, but not in the past year",
-                    "Yes, during the past year"
-                ]
-            },
-            "auditnd": {
-                "description": "auditnd",
-                "enum": [
-                    "No",
-                    "Yes",
-                    "null"
-                ]
-            },
-            "adtcomploth": {
-                "description": "adtcomploth",
-                "type": [
-                    "string",
-                    "null"
-                ]
-            },
-            "adt0101": {
-                "description": "adt0101",
-                "enum": [
-                    "2 to 3 times a week",
-                    "2 to 4 times a month",
-                    "4 or more times a week",
-                    "Monthly or less",
-                    "Never",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0102": {
-                "description": "adt0102",
-                "enum": [
-                    "1 or 2",
-                    "3 or 4",
-                    "5 or 6",
-                    "7 to 9",
-                    "10 or more",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0103": {
-                "description": "adt0103",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0104": {
-                "description": "adt0104",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0105": {
-                "description": "adt0105",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0106": {
-                "description": "adt0106",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0107": {
-                "description": "adt0107",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0108": {
-                "description": "adt0108",
-                "enum": [
-                    "Never",
-                    "Weekly",
-                    "Less than monthly",
-                    "Daily or almost daily",
-                    "Monthly",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0109": {
-                "description": "adt0109",
-                "enum": [
-                    "No",
-                    "Yes, during the last year",
-                    "Yes, but not in the last year",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "adt0110": {
-                "description": "adt0110",
-                "enum": [
-                    "No",
-                    "Yes, during the last year",
-                    "Yes, but not in the last year",
-                    "Not Done/Missing",
-                    "null"
-                ]
-            },
-            "cases": {
+            "mirna_expression_calling_workflows": {
                 "$ref": "_definitions.yaml#/to_one"
             },
-            "project_id": {
-                "$ref": "_definitions.yaml#/project_id"
-            },
-            "created_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
-            },
-            "updated_datetime": {
-                "$ref": "_definitions.yaml#/datetime"
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_one"
             }
         }
     },
-    "somatic_copy_number_workflow.yaml": {
+    "structural_variation.yaml": {
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "somatic_copy_number_workflow",
-        "title": "Somatic Copy Number Workflow",
+        "id": "structural_variation",
+        "title": "structural_variation",
         "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "analysis",
-        "project": "*",
+        "namespace": "http://gdc.nci.nih.gov",
+        "category": "data_file",
         "program": "*",
-        "description": "Metadata for the Somatic Copy Number pipeline used to estimate copy number changes from different molecular data sources.",
+        "project": "*",
+        "description": "Structural_variation reads that are used as input to GDC workflows.\n",
+        "additionalProperties": false,
+        "submittable": true,
+        "validators": null,
+        "systemProperties": [
+            "id",
+            "project_id",
+            "created_datetime",
+            "updated_datetime",
+            "state",
+            "file_state",
+            "error_type"
+        ],
+        "links": [
+            {
+                "exclusive": true,
+                "required": true,
+                "subgroup": [
+                    {
+                        "name": "genomic_profile_harmonization_workflows",
+                        "backref": "structural_variations",
+                        "label": "data_from",
+                        "target_type": "genomic_profile_harmonization_workflow",
+                        "multiplicity": "one_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "structural_variant_calling_workflows",
+                        "backref": "structural_variations",
+                        "label": "data_from",
+                        "target_type": "structural_variant_calling_workflow",
+                        "multiplicity": "many_to_one",
+                        "required": false
+                    },
+                    {
+                        "name": "core_metadata_collections",
+                        "backref": "structural_variations",
+                        "label": "data_from",
+                        "target_type": "core_metadata_collection",
+                        "multiplicity": "one_to_many",
+                        "required": false
+                    }
+                ]
+            }
+        ],
+        "required": [
+            "type",
+            "submitter_id",
+            "file_name",
+            "file_size",
+            "data_format",
+            "md5sum",
+            "data_category",
+            "data_type",
+            "experimental_strategy"
+        ],
+        "uniqueKeys": [
+            [
+                "id"
+            ],
+            [
+                "project_id",
+                "submitter_id"
+            ]
+        ],
+        "properties": {
+            "$ref": "_definitions.yaml#/data_file_properties",
+            "type": {
+                "enum": [
+                    "aligned_reads"
+                ]
+            },
+            "data_category": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_category"
+                },
+                "enum": [
+                    "Somatic Structural Variation",
+                    "Structural Variation"
+                ]
+            },
+            "data_type": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_type"
+                },
+                "enum": [
+                    "Structural Alteration",
+                    "Structural Rearrangement",
+                    "Transcript Fusion"
+                ]
+            },
+            "data_format": {
+                "term": {
+                    "$ref": "_terms.yaml#/data_format"
+                },
+                "enum": [
+                    "BAM",
+                    "BEDPE",
+                    "CSV",
+                    "FASTA",
+                    "GVF",
+                    "JSON",
+                    "TSV",
+                    "TXT",
+                    "VCF"
+                ]
+            },
+            "experimental_strategy": {
+                "term": {
+                    "$ref": "_terms.yaml#/experimental_strategy"
+                },
+                "enum": [
+                    "WGS",
+                    "WXS",
+                    "Low Pass WGS",
+                    "Validation",
+                    "RNA-Seq",
+                    "miRNA-Seq",
+                    "Targeted Sequencing",
+                    "Total RNA-Seq",
+                    "DNA Panel"
+                ]
+            },
+            "genomic_profile_harmonization_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "structural_variant_calling_workflows": {
+                "$ref": "_definitions.yaml#/to_one"
+            },
+            "core_metadata_collections": {
+                "$ref": "_definitions.yaml#/to_many"
+            }
+        }
+    },
+    "alignment_cocleaning_workflow.yaml": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "alignment_cocleaning_workflow",
+        "title": "Alignment Cocleaning Workflow",
+        "type": "object",
+        "namespace": "https://dcp.bionimbus.org/",
+        "category": "analysis",
+        "program": "*",
+        "project": "*",
+        "description": "Metadata for the alignment and cocleaning pipeline used to align reads in the GDC harmonization pipelines.\n",
         "additionalProperties": false,
         "submittable": false,
         "validators": null,
@@ -11638,19 +12142,19 @@
                 "required": true,
                 "subgroup": [
                     {
-                        "name": "submitted_genotyping_arrays",
-                        "backref": "somatic_copy_number_workflows",
+                        "name": "submitted_aligned_reads_files",
+                        "backref": "alignment_cocleaning_workflows",
                         "label": "performed_on",
-                        "target_type": "submitted_genotyping_array",
-                        "multiplicity": "many_to_many",
+                        "target_type": "submitted_aligned_reads",
+                        "multiplicity": "one_to_many",
                         "required": false
                     },
                     {
-                        "name": "aligned_reads_files",
-                        "backref": "somatic_copy_number_workflows",
+                        "name": "submitted_unaligned_reads_files",
+                        "backref": "alignment_cocleaning_workflows",
                         "label": "performed_on",
-                        "target_type": "aligned_reads",
-                        "multiplicity": "many_to_many",
+                        "target_type": "submitted_unaligned_reads",
+                        "multiplicity": "one_to_many",
                         "required": false
                     }
                 ]
@@ -11673,374 +12177,23 @@
         ],
         "properties": {
             "$ref": "_definitions.yaml#/workflow_properties",
+            "type": {
+                "enum": [
+                    "alignment_cocleaning_workflow"
+                ]
+            },
             "workflow_type": {
                 "term": {
                     "$ref": "_terms.yaml#/workflow_type"
                 },
                 "enum": [
-                    "ABSOLUTE LiftOver",
-                    "ASCAT3",
-                    "ASCAT2",
-                    "AscatNGS",
-                    "GATK4 CNV"
-                ]
-            },
-            "submitted_genotyping_arrays": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "submitted_genotyping_array.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "submitted_genotyping_array",
-        "title": "Submitted Genotyping Array",
-        "type": "object",
-        "namespace": "https://gdc.cancer.gov",
-        "category": "data_file",
-        "project": "*",
-        "program": "*",
-        "description": "Data file containing raw data from a genotyping array.",
-        "additionalProperties": false,
-        "submittable": true,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "file_state",
-            "state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "aliquots",
-                        "backref": "submitted_genotyping_arrays",
-                        "label": "derived_from",
-                        "target_type": "aliquot",
-                        "multiplicity": "many_to_one",
-                        "required": true
-                    },
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "submitted_genotyping_arrays",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_format",
-            "data_type",
-            "experimental_strategy",
-            "platform"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Copy Number Variation"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Raw Intensities"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "CEL"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "Genotyping Array"
-                ]
-            },
-            "platform": {
-                "term": {
-                    "$ref": "_terms.yaml#/platform"
-                },
-                "enum": [
-                    "Affymetrix SNP 6.0"
-                ]
-            },
-            "aliquots": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
-                "$ref": "_definitions.yaml#/to_one"
-            }
-        }
-    },
-    "alignment_workflow.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "alignment_workflow",
-        "title": "Alignment Workflow",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "analysis",
-        "program": "*",
-        "project": "*",
-        "description": "Metadata for the alignment pipeline used to align reads in the GDC harmonization pipelines.\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state"
-        ],
-        "links": [
-            {
-                "exclusive": true,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "alignment_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_unaligned_reads_files",
-                        "backref": "alignment_workflows",
-                        "label": "performed_on",
-                        "target_type": "submitted_unaligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "workflow_type"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/workflow_properties",
-            "type": {
-                "enum": [
-                    "alignment_workflow"
-                ]
-            },
-            "workflow_type": {
-                "enum": [
-                    "STAR",
-                    "BWA-aln",
-                    "BWA-mem",
-                    "spinnaker"
+                    "BWA with Mark Duplicates and Cocleaning"
                 ]
             },
             "submitted_aligned_reads_files": {
                 "$ref": "_definitions.yaml#/to_many"
             },
             "submitted_unaligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            }
-        }
-    },
-    "aligned_reads.yaml": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "id": "aligned_reads",
-        "title": "Aligned Reads",
-        "type": "object",
-        "namespace": "https://dcp.bionimbus.org/",
-        "category": "data_file",
-        "program": "*",
-        "project": "*",
-        "description": "Data file containing aligned reads that are generated internally by the GDC.\n",
-        "additionalProperties": false,
-        "submittable": false,
-        "validators": null,
-        "systemProperties": [
-            "id",
-            "project_id",
-            "created_datetime",
-            "updated_datetime",
-            "state",
-            "file_state",
-            "error_type"
-        ],
-        "links": [
-            {
-                "exclusive": false,
-                "required": true,
-                "subgroup": [
-                    {
-                        "name": "core_metadata_collections",
-                        "backref": "aligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "core_metadata_collection",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "alignment_cocleaning_workflows",
-                        "backref": "aligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "alignment_cocleaning_workflow",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "alignment_workflows",
-                        "backref": "aligned_reads_files",
-                        "label": "data_from",
-                        "target_type": "alignment_workflow",
-                        "multiplicity": "many_to_one",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_unaligned_reads_files",
-                        "backref": "aligned_reads_files",
-                        "label": "matched_to",
-                        "target_type": "submitted_unaligned_reads",
-                        "multiplicity": "one_to_many",
-                        "required": false
-                    },
-                    {
-                        "name": "submitted_aligned_reads_files",
-                        "backref": "aligned_reads_files",
-                        "label": "matched_to",
-                        "target_type": "submitted_aligned_reads",
-                        "multiplicity": "one_to_one",
-                        "required": false
-                    }
-                ]
-            }
-        ],
-        "required": [
-            "type",
-            "submitter_id",
-            "file_name",
-            "file_size",
-            "md5sum",
-            "data_category",
-            "data_type",
-            "data_format",
-            "experimental_strategy",
-            "platform"
-        ],
-        "uniqueKeys": [
-            [
-                "id"
-            ],
-            [
-                "project_id",
-                "submitter_id"
-            ]
-        ],
-        "properties": {
-            "$ref": "_definitions.yaml#/data_file_properties",
-            "data_category": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_category"
-                },
-                "enum": [
-                    "Sequencing Data",
-                    "Sequencing Reads",
-                    "Raw Sequencing Data"
-                ]
-            },
-            "data_type": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_type"
-                },
-                "enum": [
-                    "Aligned Reads"
-                ]
-            },
-            "data_format": {
-                "term": {
-                    "$ref": "_terms.yaml#/data_format"
-                },
-                "enum": [
-                    "BAM",
-                    "CRAM"
-                ]
-            },
-            "experimental_strategy": {
-                "term": {
-                    "$ref": "_terms.yaml#/experimental_strategy"
-                },
-                "enum": [
-                    "WGS",
-                    "WXS",
-                    "Low Pass WGS",
-                    "Validation",
-                    "RNA-Seq",
-                    "miRNA-Seq",
-                    "Total RNA-Seq"
-                ]
-            },
-            "platform": {
-                "$ref": "read_group.yaml#/properties/platform"
-            },
-            "alignment_cocleaning_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "alignment_workflows": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "submitted_unaligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_many"
-            },
-            "submitted_aligned_reads_files": {
-                "$ref": "_definitions.yaml#/to_one"
-            },
-            "core_metadata_collections": {
                 "$ref": "_definitions.yaml#/to_many"
             }
         }


### PR DESCRIPTION
## Release 2.4.0

### Changes
- Added protein_expression schema node for proteomics data files

### Schema Details
The new protein_expression node:
- Category: data_file
- Links to core_metadata_collection (many_to_many) and lab (many_to_one)
- Supports proteomics experimental strategies: Reverse Phase Protein Array, LC-MS/MS, TMT, Label-Free, DIA, DDA, SWATH
- Includes fields for measurement_type, instrument_model, and software_version

### Validation
All 20 dictionary validation tests pass with tag \2.4.0\.